### PR TITLE
[MVP][US-03] セッション一覧と残席ステータス表示を実装

### DIFF
--- a/backend/src/main/java/com/event/reservation/ReservationService.java
+++ b/backend/src/main/java/com/event/reservation/ReservationService.java
@@ -1,6 +1,12 @@
 package com.event.reservation;
 
 import com.event.reservation.api.ReservationResponse;
+import com.event.reservation.api.SessionAvailabilityStatus;
+import com.event.reservation.api.SessionSummaryResponse;
+import com.event.reservation.api.SessionSummaryResponse.SessionSummary;
+import java.time.LocalTime;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
@@ -10,7 +16,11 @@ import org.springframework.stereotype.Service;
 @Service
 public class ReservationService {
 
+    private static final int FEW_SEATS_THRESHOLD = 20;
+    private static final int REGULAR_SESSION_CAPACITY = 200;
     private static final String KEYNOTE_SESSION = "keynote";
+    private static final DateTimeFormatter START_TIME_FORMATTER = DateTimeFormatter.ofPattern("HH:mm");
+    private static final List<SessionDefinition> SESSION_CATALOG = createSessionCatalog();
 
     private final int keynoteCapacity;
     private final Object keynoteLock = new Object();
@@ -38,5 +48,62 @@ public class ReservationService {
             keynoteReservations.add(guestId);
         }
         return new ReservationResponse(guestId, List.of(KEYNOTE_SESSION), true);
+    }
+
+    public SessionSummaryResponse listSessions() {
+        int keynoteReservedCount = keynoteReservations.size();
+        List<SessionSummary> sessions = new ArrayList<>(SESSION_CATALOG.size());
+        for (SessionDefinition sessionDefinition : SESSION_CATALOG) {
+            int remainingSeats = sessionDefinition.sessionId.equals(KEYNOTE_SESSION)
+                ? Math.max(0, keynoteCapacity - keynoteReservedCount)
+                : REGULAR_SESSION_CAPACITY;
+            sessions.add(new SessionSummary(
+                sessionDefinition.sessionId,
+                sessionDefinition.title,
+                sessionDefinition.startTime.format(START_TIME_FORMATTER),
+                sessionDefinition.track,
+                toAvailabilityStatus(remainingSeats)
+            ));
+        }
+        return new SessionSummaryResponse(sessions);
+    }
+
+    private static SessionAvailabilityStatus toAvailabilityStatus(int remainingSeats) {
+        if (remainingSeats <= 0) {
+            return SessionAvailabilityStatus.FULL;
+        }
+        if (remainingSeats < FEW_SEATS_THRESHOLD) {
+            return SessionAvailabilityStatus.FEW_LEFT;
+        }
+        return SessionAvailabilityStatus.OPEN;
+    }
+
+    private static List<SessionDefinition> createSessionCatalog() {
+        List<SessionDefinition> sessions = new ArrayList<>();
+        sessions.add(new SessionDefinition(KEYNOTE_SESSION, "Opening Keynote", "Keynote", LocalTime.of(9, 0)));
+
+        LocalTime[] regularStartTimes = {
+            LocalTime.of(10, 30),
+            LocalTime.of(11, 30),
+            LocalTime.of(13, 30),
+            LocalTime.of(14, 30),
+            LocalTime.of(15, 30)
+        };
+        String[] tracks = {"Track A", "Track B", "Track C"};
+
+        int sequence = 1;
+        for (LocalTime startTime : regularStartTimes) {
+            for (String track : tracks) {
+                String sessionId = "session-" + sequence;
+                String title = "Session " + sequence;
+                sessions.add(new SessionDefinition(sessionId, title, track, startTime));
+                sequence++;
+            }
+        }
+
+        return List.copyOf(sessions);
+    }
+
+    private record SessionDefinition(String sessionId, String title, String track, LocalTime startTime) {
     }
 }

--- a/backend/src/main/java/com/event/reservation/api/ReservationController.java
+++ b/backend/src/main/java/com/event/reservation/api/ReservationController.java
@@ -25,6 +25,11 @@ public class ReservationController {
         return reservationService.listReservations(authentication.getName());
     }
 
+    @GetMapping("/sessions")
+    public SessionSummaryResponse listSessions() {
+        return reservationService.listSessions();
+    }
+
     @PostMapping("/keynote")
     public ReservationResponse reserveKeynote(Authentication authentication) {
         return reservationService.reserveKeynote(authentication.getName());

--- a/backend/src/main/java/com/event/reservation/api/SessionAvailabilityStatus.java
+++ b/backend/src/main/java/com/event/reservation/api/SessionAvailabilityStatus.java
@@ -1,0 +1,7 @@
+package com.event.reservation.api;
+
+public enum SessionAvailabilityStatus {
+    OPEN,
+    FEW_LEFT,
+    FULL
+}

--- a/backend/src/main/java/com/event/reservation/api/SessionSummaryResponse.java
+++ b/backend/src/main/java/com/event/reservation/api/SessionSummaryResponse.java
@@ -1,0 +1,15 @@
+package com.event.reservation.api;
+
+import java.util.List;
+
+public record SessionSummaryResponse(List<SessionSummary> sessions) {
+
+    public record SessionSummary(
+        String sessionId,
+        String title,
+        String startTime,
+        String track,
+        SessionAvailabilityStatus availabilityStatus
+    ) {
+    }
+}

--- a/backend/src/test/java/com/event/reservation/ReservationServiceTest.java
+++ b/backend/src/test/java/com/event/reservation/ReservationServiceTest.java
@@ -1,0 +1,33 @@
+package com.event.reservation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.event.reservation.api.SessionAvailabilityStatus;
+import com.event.reservation.api.SessionSummaryResponse;
+import org.junit.jupiter.api.Test;
+
+class ReservationServiceTest {
+
+    @Test
+    void listSessionsReturnsFewLeftForKeynoteWhenRemainingSeatsBelowThreshold() {
+        ReservationService reservationService = new ReservationService(20);
+        for (int i = 0; i < 19; i++) {
+            reservationService.reserveKeynote("guest-" + i);
+        }
+
+        SessionSummaryResponse response = reservationService.listSessions();
+
+        assertThat(response.sessions()).hasSize(16);
+        assertThat(response.sessions().getFirst().availabilityStatus()).isEqualTo(SessionAvailabilityStatus.FEW_LEFT);
+    }
+
+    @Test
+    void listSessionsReturnsFullForKeynoteWhenCapacityReached() {
+        ReservationService reservationService = new ReservationService(1);
+        reservationService.reserveKeynote("guest-1");
+
+        SessionSummaryResponse response = reservationService.listSessions();
+
+        assertThat(response.sessions().getFirst().availabilityStatus()).isEqualTo(SessionAvailabilityStatus.FULL);
+    }
+}

--- a/backend/src/test/java/com/event/security/GuestAuthenticationFlowTest.java
+++ b/backend/src/test/java/com/event/security/GuestAuthenticationFlowTest.java
@@ -69,6 +69,25 @@ class GuestAuthenticationFlowTest {
     }
 
     @Test
+    void sessionListApiIsAvailableForGuestLogin() throws Exception {
+        MvcResult loginResult = mockMvc.perform(post("/api/auth/guest"))
+            .andExpect(status().isOk())
+            .andReturn();
+
+        JsonNode loginResponse = objectMapper.readTree(loginResult.getResponse().getContentAsString());
+        String accessToken = loginResponse.get("accessToken").asText();
+
+        mockMvc.perform(get("/api/reservations/sessions")
+                .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.sessions.length()").value(16))
+            .andExpect(jsonPath("$.sessions[0].sessionId").value("keynote"))
+            .andExpect(jsonPath("$.sessions[0].availabilityStatus").value("FEW_LEFT"))
+            .andExpect(jsonPath("$.sessions[1].startTime").isNotEmpty())
+            .andExpect(jsonPath("$.sessions[1].track").isNotEmpty());
+    }
+
+    @Test
     void keynoteReservationRegistersGuest() throws Exception {
         MvcResult loginResult = mockMvc.perform(post("/api/auth/guest"))
             .andExpect(status().isOk())

--- a/frontend/e2e/us01-guest-login.spec.ts
+++ b/frontend/e2e/us01-guest-login.spec.ts
@@ -15,12 +15,14 @@ test.describe('US-01 ゲストログイン', () => {
     await page.reload();
 
     await expect(page.getByRole('button', { name: 'ゲストでログイン' })).toBeVisible();
+    await expect(page.getByRole('button', { name: 'セッション一覧を取得' })).toBeDisabled();
     await expect(page.getByRole('button', { name: '予約一覧を取得' })).toBeDisabled();
     await expect(page.getByRole('button', { name: 'キーノートを予約' })).toBeDisabled();
 
     await page.getByRole('button', { name: 'ゲストでログイン' }).click();
 
     await expect(page.getByText('ログイン中:')).toBeVisible();
+    await expect(page.getByRole('button', { name: 'セッション一覧を取得' })).toBeEnabled();
     await expect(page.getByRole('button', { name: '予約一覧を取得' })).toBeEnabled();
     await expect(page.getByRole('button', { name: 'キーノートを予約' })).toBeEnabled();
   });

--- a/frontend/e2e/us03-session-list.spec.ts
+++ b/frontend/e2e/us03-session-list.spec.ts
@@ -1,0 +1,30 @@
+import { expect, test } from '@playwright/test';
+
+test.describe('US-03 セッション一覧と残席ステータス', () => {
+  test('ゲストはセッション一覧で時刻・トラック・3段階ステータスを確認できる', async ({ page }) => {
+    await page.goto('/');
+    await page.evaluate(() => {
+      localStorage.removeItem('guestAccessToken');
+      localStorage.removeItem('guestId');
+    });
+    await page.reload();
+
+    await page.getByRole('button', { name: 'ゲストでログイン' }).click();
+    await expect(page.getByText('ログイン中:')).toBeVisible();
+
+    await page.getByRole('button', { name: 'セッション一覧を取得' }).click();
+
+    const rows = page.locator('tbody tr');
+    await expect(rows).toHaveCount(16);
+    await expect(page.getByRole('columnheader', { name: '開始時刻' })).toBeVisible();
+    await expect(page.getByRole('columnheader', { name: 'トラック' })).toBeVisible();
+    await expect(page.getByRole('columnheader', { name: '残席ステータス' })).toBeVisible();
+
+    const statusCells = page.locator('tbody tr td:nth-child(4)');
+    const statuses = await statusCells.allInnerTexts();
+    for (const status of statuses) {
+      expect(['受付中', '残りわずか', '満席']).toContain(status.trim());
+    }
+    await expect(statusCells.filter({ hasText: /\d/ })).toHaveCount(0);
+  });
+});

--- a/frontend/src/App.test.ts
+++ b/frontend/src/App.test.ts
@@ -13,6 +13,8 @@ describe('App', () => {
     const wrapper = mount(App);
 
     expect(wrapper.text()).toContain('ゲストでログイン');
+    expect(wrapper.text()).toContain('セッション一覧');
+    expect(wrapper.text()).toContain('セッション一覧を取得');
     expect(wrapper.text()).toContain('予約一覧を取得');
     expect(wrapper.text()).toContain('キーノートを予約');
   });


### PR DESCRIPTION
## 概要
- Issue #3 (US-03) に対して、参加者がセッション一覧と残席ステータスを確認できる機能を追加。

## 変更内容
- Backend に `GET /api/reservations/sessions` を追加し、キーノート1件 + 通常セッション15件の計16件を返却するようにした
- 残席表示を `OPEN / FEW_LEFT / FULL` の3段階に統一し、Frontend で `受付中 / 残りわずか / 満席` 表示へ変換するようにした
- Frontend にセッション一覧テーブル（開始時刻・トラック・セッション名・残席ステータス）を追加し、US-03 向け E2E/テストを追加した

## 確認手順
1. `cd backend && ./gradlew test` を実行する
2. `cd frontend && pnpm test` を実行する
3. `cd frontend && pnpm e2e` を実行し、US-01/02/03 の E2E が通ることを確認する

## テスト
- [x] `frontend` のテストを実行した
- [x] `backend` のテストを実行した
- [x] ローカルで起動確認した

実行コマンド（必要に応じて）:
```bash
cd backend && ./gradlew test
cd frontend && pnpm test
cd frontend && pnpm e2e
```

## 影響範囲
- [x] Frontend
- [x] Backend
- [ ] Database（Migrationあり）
- [ ] CI/CD
- [ ] ドキュメント

## 破壊的変更
- [x] なし
- [ ] あり（内容を記載）

## 関連Issue
- Closes #3
- Related なし

## レビューポイント
- `/api/reservations/sessions` のレスポンス構造と、残席ステータス3段階の判定ロジックが要件に合っているか
- Frontend の一覧表示で残席実数が表示されず、開始時刻・トラック情報が確認できること

## 補足
- 既存 `tmp/` は本PRの変更対象外です。
