### PR TITLE
[MVP][US-05] 予約変更・キャンセルを締切前のみ可能にする

### DIFF
--- a/backend/src/main/java/com/event/reservation/api/ReservationController.java
+++ b/backend/src/main/java/com/event/reservation/api/ReservationController.java
@@ -5,6 +5,7 @@ import com.event.reservation.ReservationService;
 import com.event.reservation.SessionCapacityExceededException;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -41,6 +42,11 @@ public class ReservationController {
     @PostMapping("/sessions/{sessionId}")
     public ReservationResponse reserveSession(Authentication authentication, @PathVariable String sessionId) {
         return reservationService.reserveSession(authentication.getName(), sessionId);
+    }
+
+    @DeleteMapping("/sessions/{sessionId}")
+    public ReservationResponse cancelSession(Authentication authentication, @PathVariable String sessionId) {
+        return reservationService.cancelSessionReservation(authentication.getName(), sessionId);
     }
 
     @ResponseStatus(HttpStatus.BAD_REQUEST)


### PR DESCRIPTION
## 概要
- 予約の変更（同時間帯の別セッションへの差し替え）とキャンセルを、締切前のみ可能にしました。

## 変更内容
- `POST /api/reservations/sessions/{sessionId}` を拡張し、同時間帯に既存予約がある場合は重複エラーではなく置き換え（変更）を実施
- `DELETE /api/reservations/sessions/{sessionId}` を追加し、締切前のみキャンセル可能に実装
- バックエンド/統合テストを新仕様に更新し、フロント予約一覧にキャンセルボタンを追加

## 確認手順
1. `cd backend && ./gradlew test`
2. `cd frontend && pnpm test`
3. フロントで任意セッションを予約後、同時間帯の別セッションを予約して差し替わること、予約一覧のキャンセルで削除されることを確認

## テスト
- [x] `frontend` のテストを実行した
- [x] `backend` のテストを実行した
- [ ] ローカルで起動確認した（未実施）

実行コマンド（必要に応じて）:
```bash
cd frontend && pnpm test
cd backend && ./gradlew test
```

## 影響範囲
- [x] Frontend
- [x] Backend
- [ ] Database（Migrationあり）
- [ ] CI/CD
- [ ] ドキュメント

## 破壊的変更
- [x] なし
- [ ] あり（内容を記載）

## 関連Issue
- Closes #5
- Related #4

## レビューポイント
- 置き換え時に同時間帯重複が残らないこと（追加後に旧予約を削除する順序）
- 締切後キャンセル時のエラーハンドリングが既存ルール違反レスポンス（400）と整合していること

## 補足
- 既存の未追跡ディレクトリ（`frontend/test-results/`, `tmp/`）は本PRに含めていません。
