### PR TITLE
fix: resolve CORS 403 on reservation delete

### DIFF
--- a/backend/src/main/java/com/event/config/SecurityConfig.java
+++ b/backend/src/main/java/com/event/config/SecurityConfig.java
@@ -48,7 +48,7 @@ public class SecurityConfig {
     CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration config = new CorsConfiguration();
         config.setAllowedOrigins(List.of("http://localhost:5173", "http://127.0.0.1:5173"));
-        config.setAllowedMethods(List.of("GET", "POST", "OPTIONS"));
+        config.setAllowedMethods(List.of("GET", "POST", "DELETE", "OPTIONS"));
         config.setAllowedHeaders(List.of("*"));
 
         UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();

--- a/backend/src/test/java/com/event/security/GuestAuthenticationFlowTest.java
+++ b/backend/src/test/java/com/event/security/GuestAuthenticationFlowTest.java
@@ -3,8 +3,11 @@ package com.event.security;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.options;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.hamcrest.Matchers.containsString;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -189,6 +192,17 @@ class GuestAuthenticationFlowTest {
             .andExpect(status().isOk())
             .andExpect(jsonPath("$.reservations").isEmpty())
             .andExpect(jsonPath("$.registered").value(false));
+    }
+
+    @Test
+    void deleteReservationPreflightAllowsBrowserCorsRequest() throws Exception {
+        mockMvc.perform(options("/api/reservations/sessions/session-1")
+                .header(HttpHeaders.ORIGIN, "http://127.0.0.1:5173")
+                .header(HttpHeaders.ACCESS_CONTROL_REQUEST_METHOD, "DELETE")
+                .header(HttpHeaders.ACCESS_CONTROL_REQUEST_HEADERS, "authorization"))
+            .andExpect(status().isOk())
+            .andExpect(header().string(HttpHeaders.ACCESS_CONTROL_ALLOW_ORIGIN, "http://127.0.0.1:5173"))
+            .andExpect(header().string(HttpHeaders.ACCESS_CONTROL_ALLOW_METHODS, containsString("DELETE")));
     }
 
     @Test


### PR DESCRIPTION
## 概要
- Issue #5 のQAで報告された「予約キャンセル時のCORS 403」を修正し、ブラウザ経由の `DELETE` を通るようにします。

## 変更内容
- `SecurityConfig` のCORS許可メソッドに `DELETE` を追加
- ブラウザ相当のプリフライト（`OPTIONS + Access-Control-Request-Method: DELETE`）が成功する統合テストを追加
- 既存の予約キャンセルAPIテストと併せて、UI操作相当の経路を回帰防止

## 確認手順
1. `cd backend && ./gradlew test`
2. フロントを `http://127.0.0.1:5173` で起動し、予約一覧からキャンセルを実行
3. ネットワークタブで `OPTIONS /api/reservations/sessions/{id}` が `200`、続く `DELETE` が成功することを確認

## テスト
- [ ] `frontend` のテストを実行した（未実施）
- [x] `backend` のテストを実行した
- [ ] ローカルで起動確認した（未実施）

実行コマンド（必要に応じて）:
```bash
cd backend && ./gradlew test
```

## 影響範囲
- [ ] Frontend
- [x] Backend
- [ ] Database（Migrationあり）
- [ ] CI/CD
- [ ] ドキュメント

## 破壊的変更
- [x] なし
- [ ] あり（内容を記載）

## 関連Issue
- Closes #5
- Related #17

## レビューポイント
- CORS設定変更が既存の `GET`/`POST` 動作に影響しないこと
- `OPTIONS` プリフライトで `Access-Control-Allow-Methods` に `DELETE` が含まれること

## 補足
- 既存の未追跡ディレクトリ（`frontend/test-results/`, `tmp/`）はこのPRに含めていません。
