### PR TITLE
[MVP][US-07] QA指摘対応: CheckInService単体テストを追加

### DIFF
--- a/backend/src/test/java/com/event/checkin/CheckInServiceTest.java
+++ b/backend/src/test/java/com/event/checkin/CheckInServiceTest.java
@@ -1,0 +1,98 @@
+package com.event.checkin;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.event.reservation.ReservationService;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class CheckInServiceTest {
+
+    private static final Clock FIXED_CLOCK = Clock.fixed(Instant.parse("2026-01-01T09:00:00Z"), ZoneOffset.UTC);
+    private ReservationService reservationService;
+    private CheckInService checkInService;
+
+    @BeforeEach
+    void setUp() {
+        reservationService = new ReservationService(200, 200, "2099-01-01", FIXED_CLOCK);
+        checkInService = new CheckInService(reservationService);
+    }
+
+    @Test
+    void checkInEventRecordsAndMarksDuplicateOnSecondScan() {
+        String payload = checkInPayload("guest-1", "keynote");
+
+        CheckInService.CheckInResult first = checkInService.checkInEvent(payload);
+        CheckInService.CheckInResult second = checkInService.checkInEvent(payload);
+
+        assertThat(first.duplicate()).isFalse();
+        assertThat(first.checkInType()).isEqualTo(CheckInType.EVENT);
+        assertThat(first.guestId()).isEqualTo("guest-1");
+        assertThat(second.duplicate()).isTrue();
+        assertThat(second.checkedInAt()).isEqualTo(first.checkedInAt());
+    }
+
+    @Test
+    void checkInSessionRecordsAndMarksDuplicateOnSecondScan() {
+        reservationService.reserveSession("guest-1", "session-1");
+        String payload = checkInPayload("guest-1", "session-1");
+
+        CheckInService.CheckInResult first = checkInService.checkInSession("session-1", payload);
+        CheckInService.CheckInResult second = checkInService.checkInSession("session-1", payload);
+
+        assertThat(first.duplicate()).isFalse();
+        assertThat(first.checkInType()).isEqualTo(CheckInType.SESSION);
+        assertThat(first.sessionId()).isEqualTo("session-1");
+        assertThat(second.duplicate()).isTrue();
+        assertThat(second.checkedInAt()).isEqualTo(first.checkedInAt());
+    }
+
+    @Test
+    void checkInSessionRejectsWhenGuestDoesNotHaveCurrentReservation() {
+        reservationService.reserveSession("guest-1", "session-1");
+        String payload = checkInPayload("guest-1", "session-1");
+        reservationService.cancelSessionReservation("guest-1", "session-1");
+
+        assertThatThrownBy(() -> checkInService.checkInSession("session-1", payload))
+            .isInstanceOf(CheckInRuleViolationException.class)
+            .hasMessage("対象ゲストはこのセッションを現在予約していません。");
+    }
+
+    @Test
+    void checkInSessionRejectsWhenQrReservationDoesNotContainTargetSession() {
+        reservationService.reserveSession("guest-1", "session-1");
+        String payload = checkInPayload("guest-1", "session-2");
+
+        assertThatThrownBy(() -> checkInService.checkInSession("session-1", payload))
+            .isInstanceOf(CheckInRuleViolationException.class)
+            .hasMessage("このQRコードでは対象セッションをチェックインできません。");
+    }
+
+    @Test
+    void checkInEventRejectsMalformedPayload() {
+        assertThatThrownBy(() -> checkInService.checkInEvent("not-a-qr"))
+            .isInstanceOf(CheckInRuleViolationException.class)
+            .hasMessage("QRコードの形式が不正です。");
+    }
+
+    @Test
+    void listCheckInsByGuestIdReturnsOnlyTargetGuestRecords() {
+        reservationService.reserveSession("guest-1", "session-1");
+        reservationService.reserveSession("guest-2", "session-2");
+        checkInService.checkInEvent(checkInPayload("guest-1", "keynote"));
+        checkInService.checkInSession("session-1", checkInPayload("guest-1", "session-1"));
+        checkInService.checkInSession("session-2", checkInPayload("guest-2", "session-2"));
+
+        assertThat(checkInService.listCheckInsByGuestId("guest-1"))
+            .hasSize(2)
+            .allMatch(item -> item.guestId().equals("guest-1"));
+    }
+
+    private String checkInPayload(String guestId, String reservations) {
+        return "event-reservation://checkin?guestId=" + guestId + "&reservations=" + reservations;
+    }
+}


### PR DESCRIPTION
## 概要
- Issue #7 のQAコメントで指摘された「チェックインドメイン単体テスト不足」を解消する。

## 変更内容
- `backend/src/test/java/com/event/checkin/CheckInServiceTest.java` を新規追加。
- イベント受付チェックイン、セッション受付チェックイン、重複チェックイン挙動の単体テストを追加。
- サーバー側予約整合性チェック（キャンセル後のチェックイン拒否）と不正QR拒否の単体テストを追加。

## 確認手順
1. `cd backend && ./gradlew test` を実行する。
2. `CheckInServiceTest` が成功することを確認する。
3. 既存の `GuestAuthenticationFlowTest` を含む全テストが成功することを確認する。

## テスト
- [ ] `frontend` のテストを実行した（未実施・変更なし）
- [x] `backend` のテストを実行した
- [ ] ローカルで起動確認した（未実施・テスト追加のみ）

実行コマンド（必要に応じて）:
```bash
cd backend && ./gradlew test
```

## 影響範囲
- [ ] Frontend
- [x] Backend
- [ ] Database（Migrationあり）
- [ ] CI/CD
- [ ] ドキュメント

## 破壊的変更
- [x] なし
- [ ] あり（内容を記載）

## 関連Issue
- Closes #7
- Related #23

## レビューポイント
- QA指摘のFail要因（CheckInServiceの単体テスト不足）を十分にカバーできているか。
- 重複チェックイン挙動と予約整合性チェックのテスト観点が妥当か。

## 補足
- QAコメント: https://github.com/autotaker/simple-event-reservation-system/issues/7#issuecomment-3904213137
