### PR TITLE
[MVP][US-09] 予約状況をCSVでエクスポートできる

### DIFF
--- a/backend/src/main/java/com/event/checkin/CheckInService.java
+++ b/backend/src/main/java/com/event/checkin/CheckInService.java
@@ -112,6 +112,16 @@ public class CheckInService {
             .toList();
     }
 
+    public Map<String, Map<String, Instant>> snapshotSessionCheckIns() {
+        synchronized (checkInLock) {
+            Map<String, Map<String, Instant>> snapshot = new HashMap<>();
+            for (Map.Entry<String, Map<String, Instant>> entry : sessionCheckInsBySession.entrySet()) {
+                snapshot.put(entry.getKey(), Map.copyOf(entry.getValue()));
+            }
+            return Map.copyOf(snapshot);
+        }
+    }
+
     private QrCodeData parseQrCodePayload(String qrCodePayload) {
         if (qrCodePayload == null || qrCodePayload.isBlank()) {
             throw new CheckInRuleViolationException("QRコードの内容が空です。");

--- a/backend/src/main/java/com/event/export/AdminExportController.java
+++ b/backend/src/main/java/com/event/export/AdminExportController.java
@@ -1,0 +1,39 @@
+package com.event.export;
+
+import java.nio.charset.StandardCharsets;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/admin/exports")
+public class AdminExportController {
+
+    private static final MediaType TEXT_CSV_UTF8 = new MediaType("text", "csv", StandardCharsets.UTF_8);
+
+    private final CsvExportService csvExportService;
+
+    public AdminExportController(CsvExportService csvExportService) {
+        this.csvExportService = csvExportService;
+    }
+
+    @GetMapping(value = "/reservations", produces = "text/csv;charset=UTF-8")
+    public ResponseEntity<String> exportReservationsCsv() {
+        return csvResponse("reservations.csv", csvExportService.exportReservationsCsv());
+    }
+
+    @GetMapping(value = "/session-checkins", produces = "text/csv;charset=UTF-8")
+    public ResponseEntity<String> exportSessionCheckInsCsv() {
+        return csvResponse("session-checkins.csv", csvExportService.exportSessionCheckInsCsv());
+    }
+
+    private ResponseEntity<String> csvResponse(String filename, String body) {
+        return ResponseEntity.ok()
+            .contentType(TEXT_CSV_UTF8)
+            .header(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=\"" + filename + "\"")
+            .body(body);
+    }
+}

--- a/backend/src/main/java/com/event/export/CsvExportService.java
+++ b/backend/src/main/java/com/event/export/CsvExportService.java
@@ -1,0 +1,91 @@
+package com.event.export;
+
+import com.event.checkin.CheckInService;
+import com.event.reservation.ReservationService;
+import com.event.reservation.ReservationService.ReservationExportRow;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import org.springframework.stereotype.Service;
+
+@Service
+public class CsvExportService {
+
+    private static final String LINE_SEPARATOR = "\r\n";
+
+    private final ReservationService reservationService;
+    private final CheckInService checkInService;
+
+    public CsvExportService(ReservationService reservationService, CheckInService checkInService) {
+        this.reservationService = reservationService;
+        this.checkInService = checkInService;
+    }
+
+    public String exportReservationsCsv() {
+        StringBuilder csvBuilder = new StringBuilder();
+        appendLine(csvBuilder, List.of("guestId", "sessionId", "sessionTitle", "startTime", "track"));
+
+        for (ReservationExportRow row : reservationService.listReservationExportRows()) {
+            appendLine(
+                csvBuilder,
+                List.of(
+                    row.guestId(),
+                    row.sessionId(),
+                    row.sessionTitle(),
+                    row.startTime(),
+                    row.track()
+                )
+            );
+        }
+        return csvBuilder.toString();
+    }
+
+    public String exportSessionCheckInsCsv() {
+        StringBuilder csvBuilder = new StringBuilder();
+        appendLine(
+            csvBuilder,
+            List.of("sessionId", "sessionTitle", "startTime", "track", "guestId", "checkedIn", "checkedInAt")
+        );
+
+        List<ReservationExportRow> reservations = reservationService.listReservationExportRows();
+        Map<String, Map<String, Instant>> checkInSnapshot = checkInService.snapshotSessionCheckIns();
+
+        for (ReservationExportRow row : reservations) {
+            Instant checkedInAt = checkInSnapshot
+                .getOrDefault(row.sessionId(), Map.of())
+                .get(row.guestId());
+            appendLine(
+                csvBuilder,
+                List.of(
+                    row.sessionId(),
+                    row.sessionTitle(),
+                    row.startTime(),
+                    row.track(),
+                    row.guestId(),
+                    Boolean.toString(checkedInAt != null),
+                    checkedInAt == null ? "" : checkedInAt.toString()
+                )
+            );
+        }
+
+        return csvBuilder.toString();
+    }
+
+    private void appendLine(StringBuilder csvBuilder, List<String> values) {
+        String joined = String.join(",", values.stream().map(this::escapeCsv).toList());
+        csvBuilder.append(joined).append(LINE_SEPARATOR);
+    }
+
+    private String escapeCsv(String rawValue) {
+        String normalizedValue = rawValue == null ? "" : rawValue;
+        String escapedValue = normalizedValue.replace("\"", "\"\"");
+        boolean needsQuote = escapedValue.contains(",")
+            || escapedValue.contains("\"")
+            || escapedValue.contains("\n")
+            || escapedValue.contains("\r");
+        if (needsQuote) {
+            return "\"" + escapedValue + "\"";
+        }
+        return escapedValue;
+    }
+}

--- a/backend/src/main/java/com/event/reservation/ReservationService.java
+++ b/backend/src/main/java/com/event/reservation/ReservationService.java
@@ -168,6 +168,29 @@ public class ReservationService {
         return new AdminSessionSummaryResponse(sessions);
     }
 
+    public List<ReservationExportRow> listReservationExportRows() {
+        synchronized (reservationLock) {
+            List<ReservationExportRow> rows = new ArrayList<>();
+            for (SessionDefinition sessionDefinition : sortedSessions()) {
+                List<String> guestIds = reservationsBySession.getOrDefault(sessionDefinition.sessionId, Set.of()).stream()
+                    .sorted()
+                    .toList();
+                for (String guestId : guestIds) {
+                    rows.add(
+                        new ReservationExportRow(
+                            guestId,
+                            sessionDefinition.sessionId,
+                            sessionDefinition.title,
+                            sessionDefinition.startTime.format(START_TIME_FORMATTER),
+                            sessionDefinition.track
+                        )
+                    );
+                }
+            }
+            return List.copyOf(rows);
+        }
+    }
+
     public AdminSessionResponse createSession(String title, String startTime, String track, Integer capacity) {
         validateSessionFields(title, startTime, track, capacity);
         LocalTime parsedStartTime = parseStartTime(startTime);
@@ -420,4 +443,12 @@ public class ReservationService {
 
     private record SessionDefinition(String sessionId, String title, String track, LocalTime startTime, int capacity) {
     }
+
+    public record ReservationExportRow(
+        String guestId,
+        String sessionId,
+        String sessionTitle,
+        String startTime,
+        String track
+    ) {}
 }

--- a/backend/src/test/java/com/event/security/GuestAuthenticationFlowTest.java
+++ b/backend/src/test/java/com/event/security/GuestAuthenticationFlowTest.java
@@ -1,17 +1,20 @@
 package com.event.security;
 
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.Matchers.containsString;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.options;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-import static org.hamcrest.Matchers.containsString;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import java.nio.charset.StandardCharsets;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
@@ -275,6 +278,86 @@ class GuestAuthenticationFlowTest {
         mockMvc.perform(get("/api/admin/sessions")
                 .header(HttpHeaders.AUTHORIZATION, "Bearer " + token))
             .andExpect(status().isForbidden());
+    }
+
+    @Test
+    void adminCanExportReservationsCsvAsUtf8() throws Exception {
+        MvcResult firstLoginResult = mockMvc.perform(post("/api/auth/guest"))
+            .andExpect(status().isOk())
+            .andReturn();
+        JsonNode firstLoginResponse = objectMapper.readTree(firstLoginResult.getResponse().getContentAsString());
+        String firstAccessToken = firstLoginResponse.get("accessToken").asText();
+        String firstGuestId = firstLoginResponse.get("guestId").asText();
+
+        MvcResult secondLoginResult = mockMvc.perform(post("/api/auth/guest"))
+            .andExpect(status().isOk())
+            .andReturn();
+        JsonNode secondLoginResponse = objectMapper.readTree(secondLoginResult.getResponse().getContentAsString());
+        String secondAccessToken = secondLoginResponse.get("accessToken").asText();
+        String secondGuestId = secondLoginResponse.get("guestId").asText();
+
+        mockMvc.perform(post("/api/reservations/sessions/session-1")
+                .header(HttpHeaders.AUTHORIZATION, "Bearer " + firstAccessToken))
+            .andExpect(status().isOk());
+        mockMvc.perform(post("/api/reservations/sessions/session-2")
+                .header(HttpHeaders.AUTHORIZATION, "Bearer " + secondAccessToken))
+            .andExpect(status().isOk());
+
+        MvcResult exportResult = mockMvc.perform(get("/api/admin/exports/reservations")
+                .header(HttpHeaders.AUTHORIZATION, "Bearer test-admin-token"))
+            .andExpect(status().isOk())
+            .andExpect(header().string(HttpHeaders.CONTENT_TYPE, containsString("text/csv")))
+            .andExpect(header().string(HttpHeaders.CONTENT_TYPE, containsString("charset=UTF-8")))
+            .andExpect(header().string(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=\"reservations.csv\""))
+            .andExpect(content().string(containsString("guestId,sessionId,sessionTitle,startTime,track")))
+            .andReturn();
+
+        String csv = exportResult.getResponse().getContentAsString(StandardCharsets.UTF_8);
+        assertThat(csv).contains(firstGuestId + ",session-1,Session 1,10:30,Track A");
+        assertThat(csv).contains(secondGuestId + ",session-2,Session 2,10:30,Track B");
+    }
+
+    @Test
+    void adminCanExportSessionCheckInsCsvAsUtf8() throws Exception {
+        MvcResult firstLoginResult = mockMvc.perform(post("/api/auth/guest"))
+            .andExpect(status().isOk())
+            .andReturn();
+        JsonNode firstLoginResponse = objectMapper.readTree(firstLoginResult.getResponse().getContentAsString());
+        String firstAccessToken = firstLoginResponse.get("accessToken").asText();
+        String firstGuestId = firstLoginResponse.get("guestId").asText();
+
+        MvcResult secondLoginResult = mockMvc.perform(post("/api/auth/guest"))
+            .andExpect(status().isOk())
+            .andReturn();
+        JsonNode secondLoginResponse = objectMapper.readTree(secondLoginResult.getResponse().getContentAsString());
+        String secondAccessToken = secondLoginResponse.get("accessToken").asText();
+        String secondGuestId = secondLoginResponse.get("guestId").asText();
+
+        mockMvc.perform(post("/api/reservations/sessions/session-1")
+                .header(HttpHeaders.AUTHORIZATION, "Bearer " + firstAccessToken))
+            .andExpect(status().isOk());
+        mockMvc.perform(post("/api/reservations/sessions/session-2")
+                .header(HttpHeaders.AUTHORIZATION, "Bearer " + secondAccessToken))
+            .andExpect(status().isOk());
+
+        mockMvc.perform(post("/api/checkins/sessions/session-1")
+                .header(HttpHeaders.AUTHORIZATION, "Bearer " + firstAccessToken)
+                .contentType("application/json")
+                .content(checkInRequestBody(toCheckInPayload(firstGuestId, "session-1"))))
+            .andExpect(status().isOk());
+
+        MvcResult exportResult = mockMvc.perform(get("/api/admin/exports/session-checkins")
+                .header(HttpHeaders.AUTHORIZATION, "Bearer test-admin-token"))
+            .andExpect(status().isOk())
+            .andExpect(header().string(HttpHeaders.CONTENT_TYPE, containsString("text/csv")))
+            .andExpect(header().string(HttpHeaders.CONTENT_TYPE, containsString("charset=UTF-8")))
+            .andExpect(header().string(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=\"session-checkins.csv\""))
+            .andExpect(content().string(containsString("sessionId,sessionTitle,startTime,track,guestId,checkedIn,checkedInAt")))
+            .andReturn();
+
+        String csv = exportResult.getResponse().getContentAsString(StandardCharsets.UTF_8);
+        assertThat(csv).contains("session-1,Session 1,10:30,Track A," + firstGuestId + ",true,");
+        assertThat(csv).contains("session-2,Session 2,10:30,Track B," + secondGuestId + ",false,");
     }
 
     @Test


### PR DESCRIPTION
## 概要
- Issue #9 の要件に沿って、運営向けに予約状況CSVとセッション別チェックイン状況CSVを出力できるようにしました。

## 変更内容
- `GET /api/admin/exports/reservations` と `GET /api/admin/exports/session-checkins` を追加
- CSV生成サービスを追加し、UTF-8（`text/csv;charset=UTF-8`）かつ `Content-Disposition: attachment` で返却
- フロント管理画面に「予約一覧CSVを出力」「チェックインCSVを出力」ボタンを追加

## 確認手順
1. 管理者トークンを設定し、管理画面でセッション予約とチェックインを作成する
2. 「予約一覧CSVを出力」を押して `reservations.csv` がダウンロードされることを確認する
3. 「チェックインCSVを出力」を押して `session-checkins.csv` がダウンロードされることを確認する

## テスト
- [x] `frontend` のテストを実行した
- [x] `backend` のテストを実行した
- [ ] ローカルで起動確認した

実行コマンド（必要に応じて）:
```bash
cd frontend && npm test -- --run
cd backend && ./gradlew test --tests com.event.security.GuestAuthenticationFlowTest
```

## 影響範囲
- [x] Frontend
- [x] Backend
- [ ] Database（Migrationあり）
- [ ] CI/CD
- [ ] ドキュメント

## 破壊的変更
- [x] なし
- [ ] あり（内容を記載）

## 関連Issue
- Closes #9
- Related #N/A

## レビューポイント
- CSVフォーマット（ヘッダ順、チェックイン有無/時刻列、エスケープ処理）が要件どおりか

## 補足
- 既存ワークツリーに未追跡ファイル（`tmp/` や `frontend/test-results/`）がありますが、本PRには含めていません。
