### PR TITLE
test: add CsvExportService domain tests for issue #9

### DIFF
--- a/backend/src/test/java/com/event/export/CsvExportServiceTest.java
+++ b/backend/src/test/java/com/event/export/CsvExportServiceTest.java
@@ -1,0 +1,89 @@
+package com.event.export;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.event.checkin.CheckInService;
+import com.event.reservation.ReservationService;
+import com.event.reservation.ReservationService.ReservationExportRow;
+import com.event.reservation.api.SessionAvailabilityStatus;
+import com.event.reservation.api.SessionSummaryResponse;
+import com.event.reservation.api.SessionSummaryResponse.SessionSummary;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class CsvExportServiceTest {
+
+    @Test
+    void exportReservationsCsvEscapesAndPreservesUtf8Characters() {
+        ReservationService reservationService = mock(ReservationService.class);
+        CheckInService checkInService = mock(CheckInService.class);
+        CsvExportService csvExportService = new CsvExportService(reservationService, checkInService);
+
+        when(reservationService.listReservationExportRows()).thenReturn(
+            List.of(
+                new ReservationExportRow(
+                    "guest-1",
+                    "session-1",
+                    "セッション, \"A\"",
+                    "10:30",
+                    "Track \"東\""
+                )
+            )
+        );
+
+        String csv = csvExportService.exportReservationsCsv();
+
+        assertThat(csv).isEqualTo(
+            "guestId,sessionId,sessionTitle,startTime,track\r\n"
+                + "guest-1,session-1,\"セッション, \"\"A\"\"\",10:30,\"Track \"\"東\"\"\"\r\n"
+        );
+    }
+
+    @Test
+    void exportSessionCheckInsCsvContainsReservationAndCheckInUnionRows() {
+        ReservationService reservationService = mock(ReservationService.class);
+        CheckInService checkInService = mock(CheckInService.class);
+        CsvExportService csvExportService = new CsvExportService(reservationService, checkInService);
+
+        when(reservationService.listReservationExportRows()).thenReturn(
+            List.of(
+                new ReservationExportRow(
+                    "guest-reserved",
+                    "session-1",
+                    "Session 1",
+                    "10:30",
+                    "Track A"
+                )
+            )
+        );
+        when(reservationService.listSessions()).thenReturn(
+            new SessionSummaryResponse(
+                List.of(
+                    new SessionSummary(
+                        "session-1",
+                        "Session 1",
+                        "10:30",
+                        "Track A",
+                        SessionAvailabilityStatus.OPEN
+                    )
+                )
+            )
+        );
+        when(checkInService.snapshotSessionCheckIns()).thenReturn(
+            Map.of(
+                "session-1",
+                Map.of("guest-checkedin-only", Instant.parse("2026-02-15T12:34:56Z"))
+            )
+        );
+
+        String csv = csvExportService.exportSessionCheckInsCsv();
+
+        assertThat(csv).contains("sessionId,sessionTitle,startTime,track,guestId,checkedIn,checkedInAt\r\n");
+        assertThat(csv).contains("session-1,Session 1,10:30,Track A,guest-reserved,false,\r\n");
+        assertThat(csv).contains("session-1,Session 1,10:30,Track A,guest-checkedin-only,true,2026-02-15T12:34:56Z\r\n");
+    }
+}


### PR DESCRIPTION
## 概要
- Issue #9 のQAコメントで指摘された「CsvExportService のドメイン単体テスト不足」を解消します。

## 変更内容
- `backend/src/test/java/com/event/export/CsvExportServiceTest.java` を新規追加
- 予約CSVの UTF-8 文字/CSVエスケープ（カンマ・ダブルクォート）を単体テストで検証
- セッションチェックインCSVが「予約 + チェックイン記録の和集合」を出力することを単体テストで検証

## 確認手順
1. `cd backend`
2. `./gradlew test --tests com.event.export.CsvExportServiceTest`
3. `./gradlew test --tests com.event.security.GuestAuthenticationFlowTest`

## テスト
- [ ] `frontend` のテストを実行した（未実施）
- [x] `backend` のテストを実行した
- [ ] ローカルで起動確認した（未実施）

実行コマンド（必要に応じて）:
```bash
cd backend && ./gradlew test --tests com.event.export.CsvExportServiceTest
cd backend && ./gradlew test --tests com.event.security.GuestAuthenticationFlowTest
```

## 影響範囲
- [ ] Frontend
- [x] Backend
- [ ] Database（Migrationあり）
- [ ] CI/CD
- [ ] ドキュメント

## 破壊的変更
- [x] なし
- [ ] あり（内容を記載）

## 関連Issue
- Closes #9
- Related #N/A

## レビューポイント
- QA指摘のFail理由（CsvExportServiceの単体テスト不足）を埋められているか

## 補足
- QAコメント（Issue #9）での「総合判定 Fail」の理由に対する追補PRです。
