### PR TITLE
[Post-MVP][US-10] QRパネルStorybookにGenerating/Error状態を追加

### DIFF
--- a/frontend/src/stories/participant-production/ParticipantQrPanel.stories.ts
+++ b/frontend/src/stories/participant-production/ParticipantQrPanel.stories.ts
@@ -17,6 +17,7 @@ export const WithQrCode: Story = {
   args: {
     qrCodePayload: 'event-reservation://checkin?guestId=Guest-A12',
     qrCodeImageUrl: qrImageUrl,
+    qrCodeGenerationStatus: 'ready',
     reservations: ['keynote', 'session-a1'],
     hasToken: true,
     disabled: false,
@@ -27,6 +28,7 @@ export const Placeholder: Story = {
   args: {
     qrCodePayload: '',
     qrCodeImageUrl: qrImageUrl,
+    qrCodeGenerationStatus: 'idle',
     reservations: [],
     hasToken: true,
     disabled: false,
@@ -37,8 +39,31 @@ export const Disabled: Story = {
   args: {
     qrCodePayload: '',
     qrCodeImageUrl: qrImageUrl,
+    qrCodeGenerationStatus: 'idle',
     reservations: [],
     hasToken: false,
     disabled: true,
+  },
+};
+
+export const Generating: Story = {
+  args: {
+    qrCodePayload: 'event-reservation://checkin?guestId=Guest-A12&reservations=keynote',
+    qrCodeImageUrl: '',
+    qrCodeGenerationStatus: 'generating',
+    reservations: ['keynote'],
+    hasToken: true,
+    disabled: false,
+  },
+};
+
+export const Error: Story = {
+  args: {
+    qrCodePayload: 'event-reservation://checkin?guestId=Guest-A12&reservations=keynote',
+    qrCodeImageUrl: '',
+    qrCodeGenerationStatus: 'error',
+    reservations: ['keynote'],
+    hasToken: true,
+    disabled: false,
   },
 };


### PR DESCRIPTION
## 概要
- Issue #28 のコメントで依頼された通り、`ParticipantQrPanel` の Production Storybook に中間/失敗状態を追加し、QR表示UIの仕様を状態単位で確認できるようにします。

## 変更内容
- `frontend/src/stories/participant-production/ParticipantQrPanel.stories.ts` に `Generating` 状態を追加
- 同ファイルに `Error` 状態を追加
- 既存 `WithQrCode / Placeholder / Disabled` に `qrCodeGenerationStatus` を明示し、コンポーネント仕様と整合させた

## 確認手順
1. `cd frontend && pnpm storybook` を実行
2. `US-12-1 Participant Production/Components/QrPanel` を開く
3. `WithQrCode / Placeholder / Disabled / Generating / Error` の5状態が表示されることを確認

## テスト
- [x] `frontend` のテストを実行した
- [ ] `backend` のテストを実行した（未実施）
- [ ] ローカルで起動確認した（Storybook自体の目視起動は未実施）

実行コマンド（必要に応じて）:
```bash
cd frontend && pnpm typecheck
```

## 影響範囲
- [x] Frontend
- [ ] Backend
- [ ] Database（Migrationあり）
- [ ] CI/CD
- [ ] ドキュメント

## 破壊的変更
- [x] なし
- [ ] あり（内容を記載）

## 関連Issue
- Closes #28
- Related #なし

## レビューポイント
- Storyの `qrCodeGenerationStatus` と表示文言（生成中/失敗）の対応が意図通りか
- 5状態が回帰検知に十分な粒度になっているか

## 補足
- 変更は Story ファイル1つのみに限定し、アプリ本体の挙動変更はありません。
