### PR TITLE
[Post-MVP][US-18] CSVインジェクション対策を実装する

### DIFF
--- a/backend/src/test/java/com/event/export/CsvExportServiceTest.java
+++ b/backend/src/test/java/com/event/export/CsvExportServiceTest.java
@@ -44,6 +44,32 @@ class CsvExportServiceTest {
     }
 
     @Test
+    void exportReservationsCsvSanitizesDangerousFormulaPrefixes() {
+        ReservationService reservationService = mock(ReservationService.class);
+        CheckInService checkInService = mock(CheckInService.class);
+        CsvExportService csvExportService = new CsvExportService(reservationService, checkInService);
+
+        when(reservationService.listReservationExportRows()).thenReturn(
+            List.of(
+                new ReservationExportRow(
+                    "=guest-1",
+                    "+session-1",
+                    "-title",
+                    "@10:30",
+                    "Track A"
+                )
+            )
+        );
+
+        String csv = csvExportService.exportReservationsCsv();
+
+        assertThat(csv).isEqualTo(
+            "guestId,sessionId,sessionTitle,startTime,track\r\n"
+                + "'=guest-1,'+session-1,'-title,'@10:30,Track A\r\n"
+        );
+    }
+
+    @Test
     void exportSessionCheckInsCsvContainsReservationAndCheckInUnionRows() {
         ReservationService reservationService = mock(ReservationService.class);
         CheckInService checkInService = mock(CheckInService.class);
@@ -85,5 +111,45 @@ class CsvExportServiceTest {
         assertThat(csv).contains("sessionId,sessionTitle,startTime,track,guestId,checkedIn,checkedInAt\r\n");
         assertThat(csv).contains("session-1,Session 1,10:30,Track A,guest-reserved,false,\r\n");
         assertThat(csv).contains("session-1,Session 1,10:30,Track A,guest-checkedin-only,true,2026-02-15T12:34:56Z\r\n");
+    }
+
+    @Test
+    void exportSessionCheckInsCsvSanitizesDangerousFormulaPrefixes() {
+        ReservationService reservationService = mock(ReservationService.class);
+        CheckInService checkInService = mock(CheckInService.class);
+        CsvExportService csvExportService = new CsvExportService(reservationService, checkInService);
+
+        when(reservationService.listReservationExportRows()).thenReturn(
+            List.of(
+                new ReservationExportRow(
+                    "=guest-reserved",
+                    "+session-1",
+                    "-Session 1",
+                    "@10:30",
+                    "Track A"
+                )
+            )
+        );
+        when(reservationService.listSessions()).thenReturn(
+            new SessionSummaryResponse(
+                List.of(
+                    new SessionSummary(
+                        "+session-1",
+                        "-Session 1",
+                        "@10:30",
+                        "Track A",
+                        SessionAvailabilityStatus.OPEN
+                    )
+                )
+            )
+        );
+        when(checkInService.snapshotSessionCheckIns()).thenReturn(Map.of());
+
+        String csv = csvExportService.exportSessionCheckInsCsv();
+
+        assertThat(csv).isEqualTo(
+            "sessionId,sessionTitle,startTime,track,guestId,checkedIn,checkedInAt\r\n"
+                + "'+session-1,'-Session 1,'@10:30,Track A,'=guest-reserved,false,\r\n"
+        );
     }
 }


### PR DESCRIPTION
## 概要
- 予約CSV・チェックインCSVに対して、先頭が危険文字（`=`, `+`, `-`, `@`）のセルを無害化するCSVインジェクション対策を追加します。

## 変更内容
- `CsvExportService` に危険文字先頭セルの無害化処理（先頭に `'` を付与）を追加
- 既存のCSVエスケープ（ダブルクォート、改行、カンマ対応）との互換性を維持
- 予約CSV/チェックインCSVの無害化を検証するユニットテストを追加

## 確認手順
1. `cd backend`
2. `./gradlew test --tests com.event.export.CsvExportServiceTest`
3. テストが成功し、危険文字先頭値が `'` 付きで出力されることを確認

## テスト
- [ ] `frontend` のテストを実行した（未実施）
- [x] `backend` のテストを実行した
- [ ] ローカルで起動確認した（未実施）

実行コマンド（必要に応じて）:
```bash
cd backend && ./gradlew test --tests com.event.export.CsvExportServiceTest
```

## 影響範囲
- [ ] Frontend
- [x] Backend
- [ ] Database（Migrationあり）
- [ ] CI/CD
- [ ] ドキュメント

## 破壊的変更
- [x] なし
- [ ] あり（内容を記載）

## 関連Issue
- Closes #36
- Related #なし（該当なし）

## レビューポイント
- 危険文字先頭セルの判定対象（`=`, `+`, `-`, `@`）が要件通りか
- 既存CSV利用者への互換性を壊さない変更になっているか

## 補足
- なし
