### PR TITLE
feat(frontend): implement css foundation for issue #31

### DIFF
--- a/frontend/src/components/admin/AdminAccessDeniedPanel.vue
+++ b/frontend/src/components/admin/AdminAccessDeniedPanel.vue
@@ -1,9 +1,11 @@
 <template>
-  <section class="denied">
+  <section class="denied ui-panel">
     <p class="denied__code">403 Forbidden</p>
     <h3>管理導線へのアクセス権限がありません</h3>
     <p class="denied__reason">{{ message }}</p>
-    <RouterLink class="denied__link" to="/participant">参加者画面へ戻る</RouterLink>
+    <RouterLink class="denied__link ui-button ui-button--danger" to="/participant">
+      参加者画面へ戻る
+    </RouterLink>
   </section>
 </template>
 
@@ -17,10 +19,6 @@ defineProps<{
 
 <style scoped>
 .denied {
-  display: grid;
-  gap: 8px;
-  padding: 12px;
-  border-radius: 14px;
   border: 1px solid var(--semantic-color-state-danger);
   background: var(--semantic-color-state-danger-soft);
 }
@@ -51,15 +49,6 @@ defineProps<{
 .denied__link {
   width: fit-content;
   min-width: 150px;
-  height: 34px;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  border-radius: 10px;
-  background: var(--semantic-color-state-danger);
-  color: var(--semantic-color-text-on-primary);
-  font-size: 12px;
-  font-weight: 700;
   text-decoration: none;
 }
 </style>

--- a/frontend/src/components/admin/AdminAccessGate.vue
+++ b/frontend/src/components/admin/AdminAccessGate.vue
@@ -1,9 +1,9 @@
 <template>
-  <section class="gate">
+  <section class="gate ui-panel">
     <h2>管理アクセス確認</h2>
-    <label>
-      管理者トークン
-      <input v-model="model" type="password" placeholder="admin token" />
+    <label class="ui-field">
+      <span class="ui-field__label">管理者トークン</span>
+      <input v-model="model" class="ui-field__input" type="password" placeholder="admin token" />
     </label>
   </section>
 </template>
@@ -20,14 +20,5 @@ const model = defineModel<string>({ required: true });
 
 .gate h2 {
   margin: 0;
-}
-
-.gate label {
-  display: grid;
-  gap: 6px;
-}
-
-.gate input {
-  max-width: 280px;
 }
 </style>

--- a/frontend/src/components/admin/AdminCsvExportPanel.vue
+++ b/frontend/src/components/admin/AdminCsvExportPanel.vue
@@ -1,12 +1,22 @@
 <template>
-  <section class="csv-panel">
+  <section class="csv-panel ui-panel">
     <h3>CSV出力</h3>
     <p>集計前に最新の予約状態へ同期してください。</p>
     <div class="csv-panel__actions">
-      <button type="button" :disabled="disabled" @click="$emit('downloadReservations')">
+      <button
+        class="ui-button ui-button--warning"
+        type="button"
+        :disabled="disabled"
+        @click="$emit('downloadReservations')"
+      >
         予約一覧CSVを出力
       </button>
-      <button type="button" :disabled="disabled" @click="$emit('downloadCheckIns')">
+      <button
+        class="ui-button ui-button--warning"
+        type="button"
+        :disabled="disabled"
+        @click="$emit('downloadCheckIns')"
+      >
         チェックインCSVを出力
       </button>
     </div>
@@ -26,12 +36,8 @@ defineEmits<{
 
 <style scoped>
 .csv-panel {
-  display: grid;
   gap: 10px;
-  padding: 12px;
-  border-radius: 14px;
   border: 1px solid var(--semantic-color-state-warning);
-  background: var(--semantic-color-bg-surface);
 }
 
 .csv-panel h3,

--- a/frontend/src/components/admin/AdminSessionEditor.vue
+++ b/frontend/src/components/admin/AdminSessionEditor.vue
@@ -1,27 +1,36 @@
 <template>
-  <form class="editor" @submit.prevent="$emit('submit')">
+  <form class="editor ui-panel" @submit.prevent="$emit('submit')">
     <h3>{{ heading }}</h3>
     <div class="editor__grid">
-      <label>
-        タイトル
-        <input v-model="title" type="text" required />
+      <label class="ui-field">
+        <span class="ui-field__label">タイトル</span>
+        <input v-model="title" class="ui-field__input" type="text" required />
       </label>
-      <label>
-        開始時刻
-        <input v-model="startTime" type="time" required />
+      <label class="ui-field">
+        <span class="ui-field__label">開始時刻</span>
+        <input v-model="startTime" class="ui-field__input" type="time" required />
       </label>
-      <label>
-        トラック
-        <input v-model="track" type="text" required />
+      <label class="ui-field">
+        <span class="ui-field__label">トラック</span>
+        <input v-model="track" class="ui-field__input" type="text" required />
       </label>
-      <label>
-        定員
-        <input v-model="capacity" type="number" min="1" required />
+      <label class="ui-field">
+        <span class="ui-field__label">定員</span>
+        <input v-model="capacity" class="ui-field__input" type="number" min="1" required />
       </label>
     </div>
     <div class="editor__actions">
-      <button type="submit" :disabled="!canSubmit">{{ submitLabel }}</button>
-      <button v-if="showCancel" type="button" @click="$emit('cancel')">キャンセル</button>
+      <button class="ui-button ui-button--warning" type="submit" :disabled="!canSubmit">
+        {{ submitLabel }}
+      </button>
+      <button
+        v-if="showCancel"
+        class="ui-button ui-button--secondary"
+        type="button"
+        @click="$emit('cancel')"
+      >
+        キャンセル
+      </button>
     </div>
   </form>
 </template>
@@ -71,12 +80,8 @@ const capacity = computed({
 
 <style scoped>
 .editor {
-  display: grid;
   gap: 10px;
-  padding: 12px;
-  border-radius: 14px;
   border: 1px solid var(--semantic-color-state-warning);
-  background: var(--semantic-color-bg-surface);
 }
 
 .editor h3 {
@@ -90,16 +95,10 @@ const capacity = computed({
   grid-template-columns: repeat(2, minmax(0, 1fr));
 }
 
-.editor label {
-  display: grid;
-  gap: 4px;
-  font-size: 12px;
-  color: var(--semantic-color-text-secondary);
-}
-
 .editor__actions {
   display: flex;
   gap: 8px;
+  flex-wrap: wrap;
 }
 
 @media (max-width: 900px) {

--- a/frontend/src/components/admin/AdminSessionTable.vue
+++ b/frontend/src/components/admin/AdminSessionTable.vue
@@ -1,39 +1,55 @@
 <template>
-  <section class="table-wrap">
+  <section class="table-wrap ui-panel">
     <header class="table-wrap__header">
       <h3>管理対象セッション</h3>
       <div class="table-wrap__actions">
         <span>{{ sessions.length }}件</span>
-        <button type="button" :disabled="disabled" @click="$emit('load')">管理一覧を取得</button>
+        <button
+          class="ui-button ui-button--warning"
+          type="button"
+          :disabled="disabled"
+          @click="$emit('load')"
+        >
+          管理一覧を取得
+        </button>
       </div>
     </header>
 
-    <table v-if="sessions.length > 0">
-      <thead>
-        <tr>
-          <th scope="col">ID</th>
-          <th scope="col">開始時刻</th>
-          <th scope="col">トラック</th>
-          <th scope="col">タイトル</th>
-          <th scope="col">定員</th>
-          <th scope="col">予約数</th>
-          <th scope="col">操作</th>
-        </tr>
-      </thead>
-      <tbody>
-        <tr v-for="session in sessions" :key="session.sessionId">
-          <td>{{ session.sessionId }}</td>
-          <td>{{ session.startTime }}</td>
-          <td>{{ session.track }}</td>
-          <td>{{ session.title }}</td>
-          <td>{{ session.capacity }}</td>
-          <td>{{ session.reservedCount }}</td>
-          <td>
-            <button type="button" :disabled="disabled" @click="$emit('edit', session)">編集</button>
-          </td>
-        </tr>
-      </tbody>
-    </table>
+    <div v-if="sessions.length > 0" class="ui-table-wrap">
+      <table class="ui-table">
+        <thead>
+          <tr>
+            <th scope="col">ID</th>
+            <th scope="col">開始時刻</th>
+            <th scope="col">トラック</th>
+            <th scope="col">タイトル</th>
+            <th scope="col">定員</th>
+            <th scope="col">予約数</th>
+            <th scope="col">操作</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr v-for="session in sessions" :key="session.sessionId">
+            <td>{{ session.sessionId }}</td>
+            <td>{{ session.startTime }}</td>
+            <td>{{ session.track }}</td>
+            <td>{{ session.title }}</td>
+            <td>{{ session.capacity }}</td>
+            <td>{{ session.reservedCount }}</td>
+            <td>
+              <button
+                class="ui-button ui-button--secondary"
+                type="button"
+                :disabled="disabled"
+                @click="$emit('edit', session)"
+              >
+                編集
+              </button>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
   </section>
 </template>
 
@@ -53,12 +69,8 @@ defineEmits<{
 
 <style scoped>
 .table-wrap {
-  display: grid;
   gap: 10px;
-  padding: 12px;
-  border-radius: 14px;
   border: 1px solid var(--semantic-color-state-warning);
-  background: var(--semantic-color-bg-surface);
 }
 
 .table-wrap__header,

--- a/frontend/src/components/operator/OperatorCheckInPanel.vue
+++ b/frontend/src/components/operator/OperatorCheckInPanel.vue
@@ -1,12 +1,15 @@
 <template>
-  <section class="operator-checkin-panel">
+  <section class="operator-checkin-panel ui-panel">
     <h2>運営チェックイン</h2>
     <p v-if="!hasToken">運営チェックインはログイン中ユーザーのみ実行できます。</p>
 
     <template v-else>
-      <label for="checkin-qr-payload">QR payload</label>
+      <label class="ui-field" for="checkin-qr-payload">
+        <span class="ui-field__label">QR payload</span>
+      </label>
       <textarea
         id="checkin-qr-payload"
+        class="ui-field__input"
         :value="qrCodePayload"
         rows="3"
         cols="60"
@@ -15,15 +18,21 @@
       />
 
       <div class="operator-checkin-panel__actions">
-        <button type="button" :disabled="disabled" @click="$emit('checkInEvent')">
+        <button
+          class="ui-button ui-button--primary"
+          type="button"
+          :disabled="disabled"
+          @click="$emit('checkInEvent')"
+        >
           イベント受付をチェックイン
         </button>
       </div>
 
       <div class="operator-checkin-panel__actions">
-        <label for="checkin-session-id">セッション受付</label>
+        <label class="ui-field__label" for="checkin-session-id">セッション受付</label>
         <select
           id="checkin-session-id"
+          class="ui-field__input"
           :value="selectedSessionId"
           :disabled="disabled"
           @change="onSessionChange"
@@ -38,6 +47,7 @@
           </option>
         </select>
         <button
+          class="ui-button ui-button--secondary"
           type="button"
           :disabled="disabled || selectedSessionId.length === 0"
           @click="$emit('checkInSession')"
@@ -46,16 +56,21 @@
         </button>
       </div>
 
-      <button type="button" :disabled="disabled" @click="$emit('refreshHistory')">
+      <button
+        class="ui-button ui-button--secondary"
+        type="button"
+        :disabled="disabled"
+        @click="$emit('refreshHistory')"
+      >
         チェックイン履歴を更新
       </button>
 
       <p
         v-if="resultMessage"
-        class="operator-checkin-panel__feedback"
+        class="operator-checkin-panel__feedback ui-status"
         :class="{
-          'operator-checkin-panel__feedback--success': resultTone === 'success',
-          'operator-checkin-panel__feedback--error': resultTone === 'error',
+          'ui-status--success': resultTone === 'success',
+          'ui-status--error': resultTone === 'error',
         }"
       >
         {{ resultMessage }}
@@ -63,27 +78,29 @@
 
       <p v-if="historyLoaded && history.length === 0">チェックイン履歴はありません。</p>
 
-      <table v-else-if="history.length > 0">
-        <thead>
-          <tr>
-            <th scope="col">チェックイン種別</th>
-            <th scope="col">ゲストID</th>
-            <th scope="col">セッションID</th>
-            <th scope="col">時刻</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr
-            v-for="entry in history"
-            :key="`${entry.checkInType}-${entry.sessionId ?? 'event'}-${entry.guestId}`"
-          >
-            <td>{{ entry.checkInTypeLabel }}</td>
-            <td>{{ entry.guestId }}</td>
-            <td>{{ entry.sessionId ?? '-' }}</td>
-            <td>{{ entry.checkedInAtLabel }}</td>
-          </tr>
-        </tbody>
-      </table>
+      <div v-else-if="history.length > 0" class="ui-table-wrap">
+        <table class="ui-table">
+          <thead>
+            <tr>
+              <th scope="col">チェックイン種別</th>
+              <th scope="col">ゲストID</th>
+              <th scope="col">セッションID</th>
+              <th scope="col">時刻</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr
+              v-for="entry in history"
+              :key="`${entry.checkInType}-${entry.sessionId ?? 'event'}-${entry.guestId}`"
+            >
+              <td>{{ entry.checkInTypeLabel }}</td>
+              <td>{{ entry.guestId }}</td>
+              <td>{{ entry.sessionId ?? '-' }}</td>
+              <td>{{ entry.checkedInAtLabel }}</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
     </template>
   </section>
 </template>
@@ -134,7 +151,6 @@ const onSessionChange = (event: globalThis.Event): void => {
 
 <style scoped>
 .operator-checkin-panel {
-  display: grid;
   gap: 10px;
 }
 
@@ -149,24 +165,17 @@ const onSessionChange = (event: globalThis.Event): void => {
   max-width: 100%;
 }
 
+.operator-checkin-panel textarea {
+  min-height: 84px;
+  padding-top: var(--space-2);
+}
+
 .operator-checkin-panel__actions {
   display: grid;
   gap: 6px;
 }
 
 .operator-checkin-panel__feedback {
-  padding: 10px;
-  border-radius: 8px;
-  font-weight: 700;
-}
-
-.operator-checkin-panel__feedback--success {
-  background: #eaf9ed;
-  color: #136428;
-}
-
-.operator-checkin-panel__feedback--error {
-  background: #ffecec;
-  color: #b20000;
+  margin-top: 2px;
 }
 </style>

--- a/frontend/src/components/operator/OperatorReservationPanel.vue
+++ b/frontend/src/components/operator/OperatorReservationPanel.vue
@@ -1,11 +1,21 @@
 <template>
-  <section class="operator-reservation-panel">
+  <section class="operator-reservation-panel ui-panel">
     <h2>予約</h2>
     <div class="operator-reservation-panel__actions">
-      <button type="button" :disabled="disabled || !hasToken" @click="$emit('refresh')">
+      <button
+        class="ui-button ui-button--secondary"
+        type="button"
+        :disabled="disabled || !hasToken"
+        @click="$emit('refresh')"
+      >
         予約一覧を取得
       </button>
-      <button type="button" :disabled="disabled || !hasToken" @click="$emit('reserveKeynote')">
+      <button
+        class="ui-button ui-button--secondary"
+        type="button"
+        :disabled="disabled || !hasToken"
+        @click="$emit('reserveKeynote')"
+      >
         キーノートを予約
       </button>
     </div>
@@ -13,10 +23,11 @@
     <p v-if="registered">参加登録: 完了</p>
     <p v-else-if="hasToken && registrationStatusLoaded">参加登録: 未完了</p>
 
-    <ul>
-      <li v-for="reservation in reservations" :key="reservation">
+    <ul class="ui-list">
+      <li v-for="reservation in reservations" :key="reservation" class="ui-list-item">
         {{ reservation }}
         <button
+          class="ui-button ui-button--secondary"
           type="button"
           :disabled="disabled || !hasToken"
           @click="$emit('cancel', reservation)"
@@ -46,7 +57,6 @@ defineEmits<{
 
 <style scoped>
 .operator-reservation-panel {
-  display: grid;
   gap: 10px;
 }
 
@@ -61,12 +71,8 @@ defineEmits<{
   flex-wrap: wrap;
 }
 
-ul {
-  margin: 0;
-  padding-left: 18px;
-}
-
-li {
-  margin-bottom: 4px;
+.operator-reservation-panel :deep(.ui-list-item) {
+  grid-template-columns: 1fr auto;
+  align-items: center;
 }
 </style>

--- a/frontend/src/components/operator/OperatorSessionTable.vue
+++ b/frontend/src/components/operator/OperatorSessionTable.vue
@@ -1,39 +1,47 @@
 <template>
-  <section class="operator-session-table">
+  <section class="operator-session-table ui-panel">
     <h2>セッション一覧</h2>
-    <button type="button" :disabled="disabled || !hasToken" @click="$emit('refresh')">
+    <button
+      class="ui-button ui-button--secondary"
+      type="button"
+      :disabled="disabled || !hasToken"
+      @click="$emit('refresh')"
+    >
       セッション一覧を取得
     </button>
     <p v-if="hasToken && sessions.length === 0">セッション一覧は未取得です。</p>
 
-    <table v-else-if="sessions.length > 0">
-      <thead>
-        <tr>
-          <th scope="col">開始時刻</th>
-          <th scope="col">トラック</th>
-          <th scope="col">セッション</th>
-          <th scope="col">残席ステータス</th>
-          <th scope="col">操作</th>
-        </tr>
-      </thead>
-      <tbody>
-        <tr v-for="session in sessions" :key="session.sessionId">
-          <td>{{ session.startTime }}</td>
-          <td>{{ session.track }}</td>
-          <td>{{ session.title }}</td>
-          <td>{{ session.availabilityStatusLabel }}</td>
-          <td>
-            <button
-              type="button"
-              :disabled="disabled || !hasToken || session.unavailable || session.reserved"
-              @click="$emit('reserve', session.sessionId, session.title)"
-            >
-              {{ session.reserved ? '予約済み' : '予約する' }}
-            </button>
-          </td>
-        </tr>
-      </tbody>
-    </table>
+    <div v-else-if="sessions.length > 0" class="ui-table-wrap">
+      <table class="ui-table">
+        <thead>
+          <tr>
+            <th scope="col">開始時刻</th>
+            <th scope="col">トラック</th>
+            <th scope="col">セッション</th>
+            <th scope="col">残席ステータス</th>
+            <th scope="col">操作</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr v-for="session in sessions" :key="session.sessionId">
+            <td>{{ session.startTime }}</td>
+            <td>{{ session.track }}</td>
+            <td>{{ session.title }}</td>
+            <td>{{ session.availabilityStatusLabel }}</td>
+            <td>
+              <button
+                class="ui-button ui-button--secondary"
+                type="button"
+                :disabled="disabled || !hasToken || session.unavailable || session.reserved"
+                @click="$emit('reserve', session.sessionId, session.title)"
+              >
+                {{ session.reserved ? '予約済み' : '予約する' }}
+              </button>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
   </section>
 </template>
 
@@ -62,7 +70,6 @@ defineEmits<{
 
 <style scoped>
 .operator-session-table {
-  display: grid;
   gap: 10px;
 }
 

--- a/frontend/src/components/participant/ParticipantQrPanel.vue
+++ b/frontend/src/components/participant/ParticipantQrPanel.vue
@@ -1,8 +1,13 @@
 <template>
-  <section class="qr-panel">
+  <section class="qr-panel ui-panel">
     <header>
       <h2>マイページ</h2>
-      <button type="button" :disabled="disabled || !hasToken" @click="$emit('refresh')">
+      <button
+        class="ui-button ui-button--secondary"
+        type="button"
+        :disabled="disabled || !hasToken"
+        @click="$emit('refresh')"
+      >
         更新
       </button>
     </header>
@@ -25,12 +30,14 @@
             ? '受付用QRコードを生成できませんでした。更新してください。'
             : qrCodePayload
               ? '受付用QRコードを生成中です...'
-            : 'ログイン後に受付QRコードが表示されます。'
+              : 'ログイン後に受付QRコードが表示されます。'
       }}
     </p>
 
-    <ul v-if="reservations.length > 0">
-      <li v-for="reservation in reservations" :key="reservation">{{ reservation }}</li>
+    <ul v-if="reservations.length > 0" class="ui-list">
+      <li v-for="reservation in reservations" :key="reservation" class="ui-list-item">
+        {{ reservation }}
+      </li>
     </ul>
   </section>
 </template>
@@ -52,13 +59,9 @@ defineEmits<{
 
 <style scoped>
 .qr-panel {
-  display: grid;
   justify-items: center;
   gap: 10px;
-  padding: 12px;
-  border-radius: 14px;
   border: 1px solid var(--semantic-color-participant-panel-qr-border);
-  background: var(--semantic-color-participant-panel-surface);
 }
 
 header {
@@ -77,20 +80,13 @@ h2 {
   font-size: 14px;
 }
 
-button {
-  height: var(--semantic-component-participant-button-secondary-height);
-  padding: 0 var(--semantic-component-participant-button-padding-x);
-  border: none;
+.qr-panel :deep(.ui-button) {
+  min-height: var(--semantic-component-participant-button-secondary-height);
   border-radius: var(--semantic-component-participant-button-secondary-radius);
   background: var(--semantic-color-participant-action-secondary-bg);
   color: var(--semantic-color-participant-action-secondary-text);
   font-size: var(--semantic-component-participant-button-text-size);
   font-weight: var(--semantic-component-participant-button-text-weight);
-}
-
-button:disabled {
-  opacity: 0.6;
-  cursor: not-allowed;
 }
 
 .qr {
@@ -118,18 +114,11 @@ p {
   color: var(--semantic-color-participant-panel-qr-label);
 }
 
-ul {
+.qr-panel :deep(.ui-list) {
   width: 100%;
-  margin: 0;
-  padding: 0;
-  list-style: none;
-  display: grid;
-  gap: 6px;
 }
 
-li {
-  padding: 8px;
-  border-radius: 10px;
+.qr-panel :deep(.ui-list-item) {
   background: var(--semantic-color-participant-panel-list-item-bg);
   font-size: 12px;
 }

--- a/frontend/src/components/participant/ParticipantReservationPanel.vue
+++ b/frontend/src/components/participant/ParticipantReservationPanel.vue
@@ -1,24 +1,39 @@
 <template>
-  <section class="reservation-panel">
+  <section class="reservation-panel ui-panel">
     <header>
       <h2>予約一覧</h2>
-      <button type="button" :disabled="disabled || !hasToken" @click="$emit('refresh')">
+      <button
+        class="ui-button ui-button--secondary"
+        type="button"
+        :disabled="disabled || !hasToken"
+        @click="$emit('refresh')"
+      >
         更新
       </button>
     </header>
 
-    <button type="button" :disabled="disabled || !hasToken" @click="$emit('reserveKeynote')">
+    <button
+      class="ui-button ui-button--secondary"
+      type="button"
+      :disabled="disabled || !hasToken"
+      @click="$emit('reserveKeynote')"
+    >
       キーノートを予約
     </button>
 
     <p v-if="registered">参加登録: 完了</p>
     <p v-else-if="hasToken && registrationStatusLoaded">参加登録: 未完了</p>
 
-    <ul v-if="reservations.length > 0">
-      <li v-for="item in reservations" :key="item.id">
+    <ul v-if="reservations.length > 0" class="ui-list">
+      <li v-for="item in reservations" :key="item.id" class="ui-list-item">
         <p>{{ item.title }}</p>
         <span>{{ item.time }}</span>
-        <button type="button" :disabled="disabled || !hasToken" @click="$emit('cancel', item.id)">
+        <button
+          class="ui-button ui-button--secondary"
+          type="button"
+          :disabled="disabled || !hasToken"
+          @click="$emit('cancel', item.id)"
+        >
           キャンセル
         </button>
       </li>
@@ -46,12 +61,8 @@ defineEmits<{
 
 <style scoped>
 .reservation-panel {
-  display: grid;
   gap: 10px;
-  padding: 12px;
-  border-radius: 14px;
   border: 1px solid var(--semantic-color-participant-panel-reservation-border);
-  background: var(--semantic-color-participant-panel-surface);
 }
 
 header {
@@ -65,10 +76,8 @@ h2 {
   font-size: 14px;
 }
 
-button {
-  height: var(--semantic-component-participant-button-secondary-height);
-  padding: 0 var(--semantic-component-participant-button-padding-x);
-  border: none;
+.reservation-panel :deep(.ui-button) {
+  min-height: var(--semantic-component-participant-button-secondary-height);
   border-radius: var(--semantic-component-participant-button-secondary-radius);
   background: var(--semantic-color-participant-action-secondary-bg);
   color: var(--semantic-color-participant-action-secondary-text);
@@ -76,24 +85,8 @@ button {
   font-weight: var(--semantic-component-participant-button-text-weight);
 }
 
-button:disabled {
-  opacity: 0.6;
-  cursor: not-allowed;
-}
-
-ul {
-  margin: 0;
-  padding: 0;
-  list-style: none;
-  display: grid;
-  gap: 8px;
-}
-
-li {
-  display: grid;
+.reservation-panel :deep(.ui-list-item) {
   gap: 4px;
-  padding: 8px;
-  border-radius: 10px;
   background: var(--semantic-color-participant-panel-list-item-bg);
 }
 

--- a/frontend/src/components/participant/ParticipantSessionCard.vue
+++ b/frontend/src/components/participant/ParticipantSessionCard.vue
@@ -6,7 +6,12 @@
       <span :class="['session-card__seat', `session-card__seat--${seatTone}`]">{{
         seatLabel
       }}</span>
-      <button type="button" :disabled="disabled" @click="$emit('reserve')">
+      <button
+        class="ui-button ui-button--primary"
+        type="button"
+        :disabled="disabled"
+        @click="$emit('reserve')"
+      >
         {{ reserved ? '予約済み' : '予約する' }}
       </button>
     </div>
@@ -84,20 +89,13 @@ defineEmits<{
   color: var(--semantic-color-participant-seat-full-text);
 }
 
-.session-card button {
-  height: var(--semantic-component-participant-button-primary-height);
-  border: none;
+.session-card :deep(.ui-button) {
+  min-height: var(--semantic-component-participant-button-primary-height);
   border-radius: var(--semantic-component-participant-button-primary-radius);
-  padding: 0 var(--semantic-component-participant-button-padding-x);
   font-size: var(--semantic-component-participant-button-text-size);
   font-weight: var(--semantic-component-participant-button-text-weight);
   background: var(--semantic-color-participant-action-primary-bg);
   color: var(--semantic-color-participant-action-primary-text);
-}
-
-.session-card button:disabled {
-  opacity: 0.6;
-  cursor: not-allowed;
 }
 
 .session-card--reserved {

--- a/frontend/src/components/participant/ParticipantTopBar.vue
+++ b/frontend/src/components/participant/ParticipantTopBar.vue
@@ -6,7 +6,14 @@
     </div>
     <div class="topbar__guest">
       <span class="topbar__badge">{{ guestName }}</span>
-      <button type="button" :disabled="disabled" @click="$emit('login')">ゲストでログイン</button>
+      <button
+        class="ui-button ui-button--primary"
+        type="button"
+        :disabled="disabled"
+        @click="$emit('login')"
+      >
+        ゲストでログイン
+      </button>
     </div>
   </header>
 </template>
@@ -69,19 +76,12 @@ defineEmits<{
   font-weight: 700;
 }
 
-.topbar button {
-  height: var(--semantic-component-participant-button-topbar-height);
-  border: none;
+.topbar :deep(.ui-button) {
+  min-height: var(--semantic-component-participant-button-topbar-height);
   border-radius: var(--semantic-component-participant-button-topbar-radius);
-  padding: 0 var(--semantic-component-participant-button-padding-x);
   background: var(--semantic-color-participant-topbar-action-bg);
   color: var(--semantic-color-participant-topbar-action-text);
   font-size: var(--semantic-component-participant-button-text-size);
   font-weight: var(--semantic-component-participant-button-text-weight);
-}
-
-.topbar button:disabled {
-  opacity: 0.6;
-  cursor: not-allowed;
 }
 </style>

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -1,6 +1,10 @@
 import { createApp } from 'vue';
 import App from './App.vue';
 import router from './router';
+import './styles/base.css';
+import './styles/layout.css';
+import './styles/components.css';
+import './styles/state.css';
 import './styles/tokens.css';
 
 createApp(App).use(router).mount('#app');

--- a/frontend/src/styles/base.css
+++ b/frontend/src/styles/base.css
@@ -1,0 +1,56 @@
+:root {
+  color-scheme: light;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html,
+body,
+#app {
+  margin: 0;
+  min-height: 100%;
+}
+
+body {
+  background: var(--semantic-color-bg-canvas);
+  color: var(--semantic-color-text-primary);
+  font-family: var(--font-family-sans);
+  font-size: var(--font-size-md);
+  line-height: var(--font-line-height-normal);
+}
+
+h1,
+h2,
+h3,
+p {
+  margin: 0;
+}
+
+a {
+  color: inherit;
+}
+
+input,
+select,
+textarea,
+button {
+  font: inherit;
+}
+
+input,
+select,
+textarea {
+  width: 100%;
+  max-width: 100%;
+}
+
+input:focus-visible,
+select:focus-visible,
+textarea:focus-visible,
+button:focus-visible,
+a:focus-visible {
+  outline: 2px solid var(--semantic-color-border-focus);
+  outline-offset: 2px;
+}

--- a/frontend/src/styles/components.css
+++ b/frontend/src/styles/components.css
@@ -1,0 +1,110 @@
+.ui-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--space-1);
+  min-height: var(--semantic-component-button-height);
+  padding: 0 var(--semantic-component-button-padding-x);
+  border-radius: var(--semantic-component-button-radius);
+  border: 1px solid transparent;
+  font-size: var(--semantic-component-button-font-size);
+  font-weight: var(--semantic-component-button-font-weight);
+  text-decoration: none;
+  cursor: pointer;
+}
+
+.ui-button--primary {
+  background: var(--semantic-color-action-primary);
+  color: var(--semantic-color-text-on-primary);
+}
+
+.ui-button--secondary {
+  background: var(--semantic-color-action-primary-soft);
+  border-color: var(--semantic-color-border-default);
+  color: var(--semantic-color-text-primary);
+}
+
+.ui-button--danger {
+  background: var(--semantic-color-state-danger);
+  color: var(--semantic-color-text-on-primary);
+}
+
+.ui-button--warning {
+  background: var(--semantic-color-state-warning);
+  color: var(--semantic-color-text-on-primary);
+}
+
+.ui-field {
+  display: grid;
+  gap: var(--space-1);
+}
+
+.ui-field__label {
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-semibold);
+  color: var(--semantic-color-text-secondary);
+}
+
+.ui-field__input {
+  height: var(--semantic-component-input-height);
+  padding: 0 var(--semantic-component-input-padding-x);
+  border: 1px solid var(--semantic-component-input-border);
+  border-radius: var(--semantic-component-input-radius);
+  background: var(--semantic-component-input-bg);
+  color: var(--semantic-component-input-text);
+}
+
+.ui-panel {
+  display: grid;
+  gap: var(--space-2);
+  padding: var(--space-3);
+  border-radius: var(--radius-lg);
+  border: 1px solid var(--semantic-color-border-default);
+  background: var(--semantic-color-bg-surface);
+}
+
+.ui-table-wrap {
+  overflow-x: auto;
+  border: 1px solid var(--semantic-color-border-default);
+  border-radius: var(--radius-lg);
+  background: var(--semantic-color-bg-surface);
+}
+
+.ui-table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.ui-table th,
+.ui-table td {
+  padding: var(--space-2) var(--space-3);
+  border-bottom: 1px solid var(--semantic-color-border-default);
+  text-align: left;
+  font-size: var(--font-size-sm);
+}
+
+.ui-table th {
+  color: var(--semantic-color-text-secondary);
+  background: var(--semantic-color-bg-subtle);
+}
+
+.ui-list {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: grid;
+  gap: var(--space-2);
+}
+
+.ui-list-item {
+  display: grid;
+  gap: var(--space-1);
+  padding: var(--space-2);
+  border-radius: var(--radius-md);
+  background: var(--semantic-color-bg-subtle);
+}
+
+.ui-muted {
+  color: var(--semantic-color-text-muted);
+  font-size: var(--font-size-sm);
+}

--- a/frontend/src/styles/layout.css
+++ b/frontend/src/styles/layout.css
@@ -1,0 +1,68 @@
+.ui-shell {
+  display: grid;
+  gap: var(--semantic-layout-card-gap);
+  width: min(var(--semantic-layout-page-max-width), 100%);
+  margin: 0 auto;
+  padding: var(--semantic-layout-card-padding);
+  border: var(--semantic-layout-card-border);
+  border-radius: var(--semantic-layout-card-radius);
+  background: var(--semantic-color-bg-surface);
+  box-shadow: var(--semantic-layout-card-shadow);
+}
+
+.ui-shell--participant {
+  border-color: var(--semantic-color-participant-portal-border);
+  background: linear-gradient(
+    160deg,
+    var(--semantic-color-participant-portal-bg-start),
+    var(--semantic-color-participant-portal-bg-mid) 48%,
+    var(--semantic-color-participant-portal-bg-end)
+  );
+}
+
+.ui-shell--participant-loading {
+  border-color: var(--semantic-color-participant-portal-border-loading);
+}
+
+.ui-shell--participant-success {
+  border-color: var(--semantic-color-participant-portal-border-success);
+}
+
+.ui-shell--participant-error {
+  border-color: var(--semantic-color-participant-portal-border-error);
+}
+
+.ui-shell--admin {
+  border-color: var(--semantic-color-state-warning);
+}
+
+.ui-shell--operator {
+  border-color: var(--semantic-color-border-strong);
+}
+
+.ui-layout-split {
+  display: grid;
+  gap: var(--space-3);
+  grid-template-columns: 1.3fr 1fr;
+}
+
+.ui-layout-stack {
+  display: grid;
+  gap: var(--space-3);
+}
+
+@media (max-width: 1023px) {
+  .ui-shell {
+    padding: var(--space-3);
+  }
+}
+
+@media (max-width: 767px) {
+  .ui-shell {
+    width: min(390px, 100%);
+  }
+
+  .ui-layout-split {
+    grid-template-columns: 1fr;
+  }
+}

--- a/frontend/src/styles/state.css
+++ b/frontend/src/styles/state.css
@@ -1,0 +1,30 @@
+.ui-status {
+  margin: 0;
+  padding: var(--space-2) var(--space-3);
+  border-radius: var(--radius-md);
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-bold);
+}
+
+.ui-status--loading {
+  background: var(--semantic-color-state-warning-soft);
+  color: var(--semantic-color-state-warning);
+}
+
+.ui-status--success {
+  background: var(--semantic-color-state-success-soft);
+  color: var(--semantic-color-state-success);
+}
+
+.ui-status--error {
+  background: var(--semantic-color-state-danger-soft);
+  color: var(--semantic-color-state-danger);
+}
+
+.ui-button:disabled,
+.ui-field__input:disabled,
+textarea:disabled,
+select:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+}

--- a/frontend/src/views/AdminView.vue
+++ b/frontend/src/views/AdminView.vue
@@ -1,5 +1,5 @@
 <template>
-  <main class="admin-portal">
+  <main class="admin-portal ui-shell ui-shell--admin">
     <AdminTopBar
       event-name="Tokyo Product Summit 2026"
       section-label="運営管理ポータル /admin"
@@ -14,16 +14,16 @@
       :message="'管理権限がないため /admin の管理画面を表示できません。管理者トークンを設定するか、参加者画面へ戻ってください。'"
     />
 
-    <p v-if="errorMessage" class="admin-portal__feedback admin-portal__feedback--error">
+    <p v-if="errorMessage" class="admin-portal__feedback ui-status ui-status--error">
       {{ errorMessage }}
     </p>
-    <p v-if="infoMessage" class="admin-portal__feedback admin-portal__feedback--success">
+    <p v-if="infoMessage" class="admin-portal__feedback ui-status ui-status--success">
       {{ infoMessage }}
     </p>
 
     <section v-if="hasAdminAccess" class="admin-portal__body">
       <h2>セッション管理（運営）</h2>
-      <div class="admin-portal__layout">
+      <div class="admin-portal__layout ui-layout-split">
         <AdminSessionTable
           :sessions="adminSessions"
           :disabled="!adminToken"
@@ -106,27 +106,12 @@ onMounted(() => {
 
 <style scoped>
 .admin-portal {
-  display: grid;
   gap: 16px;
-  width: min(960px, 100%);
-  margin: 0 auto;
   padding: 20px;
 }
 
 .admin-portal__feedback {
   margin: 0;
-}
-
-.admin-portal__feedback--forbidden {
-  color: #8a5a00;
-}
-
-.admin-portal__feedback--error {
-  color: #b20000;
-}
-
-.admin-portal__feedback--success {
-  color: #136428;
 }
 
 .admin-portal__body {
@@ -139,9 +124,7 @@ onMounted(() => {
 }
 
 .admin-portal__layout {
-  display: grid;
   gap: 12px;
-  grid-template-columns: 1.3fr 1fr;
 }
 
 .admin-portal__side {
@@ -152,12 +135,7 @@ onMounted(() => {
 
 @media (max-width: 900px) {
   .admin-portal {
-    width: min(390px, 100%);
     padding: 12px;
-  }
-
-  .admin-portal__layout {
-    grid-template-columns: 1fr;
   }
 }
 </style>

--- a/frontend/src/views/OperatorView.vue
+++ b/frontend/src/views/OperatorView.vue
@@ -1,26 +1,43 @@
 <template>
-  <main>
+  <main class="operator-portal ui-shell ui-shell--operator">
     <h1>Event Reservation MVP</h1>
     <p>ゲストでログインしてキーノート予約を行えます。</p>
 
-    <button type="button" @click="loginAsGuest">ゲストでログイン</button>
-    <p v-if="guestId">ログイン中: {{ guestId }}</p>
-    <p v-if="errorMessage">{{ errorMessage }}</p>
-    <p v-if="infoMessage">{{ infoMessage }}</p>
+    <button class="ui-button ui-button--primary" type="button" @click="loginAsGuest">
+      ゲストでログイン
+    </button>
+    <p v-if="guestId" class="ui-muted">ログイン中: {{ guestId }}</p>
+    <p v-if="errorMessage" class="ui-status ui-status--error">{{ errorMessage }}</p>
+    <p v-if="infoMessage" class="ui-status ui-status--success">{{ infoMessage }}</p>
 
-    <section>
+    <section class="ui-panel operator-portal__section">
       <h2>セッション管理（運営）</h2>
-      <label>
-        管理者トークン
+      <label class="ui-field">
+        <span class="ui-field__label">管理者トークン</span>
         <input v-model="adminToken" type="password" placeholder="admin token" />
       </label>
-      <button type="button" :disabled="!adminToken" @click="loadAdminSessions">
+      <button
+        class="ui-button ui-button--secondary"
+        type="button"
+        :disabled="!adminToken"
+        @click="loadAdminSessions"
+      >
         管理一覧を取得
       </button>
-      <button type="button" :disabled="!adminToken" @click="downloadReservationCsv">
+      <button
+        class="ui-button ui-button--secondary"
+        type="button"
+        :disabled="!adminToken"
+        @click="downloadReservationCsv"
+      >
         予約一覧CSVを出力
       </button>
-      <button type="button" :disabled="!adminToken" @click="downloadSessionCheckInCsv">
+      <button
+        class="ui-button ui-button--secondary"
+        type="button"
+        :disabled="!adminToken"
+        @click="downloadSessionCheckInCsv"
+      >
         チェックインCSVを出力
       </button>
 
@@ -42,37 +59,46 @@
           定員
           <input v-model="createForm.capacity" type="number" min="1" required />
         </label>
-        <button type="submit" :disabled="!adminToken">セッション作成</button>
+        <button class="ui-button ui-button--primary" type="submit" :disabled="!adminToken">
+          セッション作成
+        </button>
       </form>
 
-      <table v-if="adminSessions.length > 0">
-        <thead>
-          <tr>
-            <th scope="col">ID</th>
-            <th scope="col">開始時刻</th>
-            <th scope="col">トラック</th>
-            <th scope="col">タイトル</th>
-            <th scope="col">定員</th>
-            <th scope="col">予約数</th>
-            <th scope="col">操作</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr v-for="session in adminSessions" :key="session.sessionId">
-            <td>{{ session.sessionId }}</td>
-            <td>{{ session.startTime }}</td>
-            <td>{{ session.track }}</td>
-            <td>{{ session.title }}</td>
-            <td>{{ session.capacity }}</td>
-            <td>{{ session.reservedCount }}</td>
-            <td>
-              <button type="button" :disabled="!adminToken" @click="startEditSession(session)">
-                編集
-              </button>
-            </td>
-          </tr>
-        </tbody>
-      </table>
+      <div v-if="adminSessions.length > 0" class="ui-table-wrap">
+        <table class="ui-table">
+          <thead>
+            <tr>
+              <th scope="col">ID</th>
+              <th scope="col">開始時刻</th>
+              <th scope="col">トラック</th>
+              <th scope="col">タイトル</th>
+              <th scope="col">定員</th>
+              <th scope="col">予約数</th>
+              <th scope="col">操作</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr v-for="session in adminSessions" :key="session.sessionId">
+              <td>{{ session.sessionId }}</td>
+              <td>{{ session.startTime }}</td>
+              <td>{{ session.track }}</td>
+              <td>{{ session.title }}</td>
+              <td>{{ session.capacity }}</td>
+              <td>{{ session.reservedCount }}</td>
+              <td>
+                <button
+                  class="ui-button ui-button--secondary"
+                  type="button"
+                  :disabled="!adminToken"
+                  @click="startEditSession(session)"
+                >
+                  編集
+                </button>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
 
       <form v-if="editForm.sessionId" @submit.prevent="updateAdminSession">
         <h3>編集: {{ editForm.sessionId }}</h3>
@@ -92,8 +118,12 @@
           定員
           <input v-model="editForm.capacity" type="number" min="1" required />
         </label>
-        <button type="submit" :disabled="!adminToken">更新</button>
-        <button type="button" @click="clearEditForm">キャンセル</button>
+        <button class="ui-button ui-button--primary" type="submit" :disabled="!adminToken">
+          更新
+        </button>
+        <button class="ui-button ui-button--secondary" type="button" @click="clearEditForm">
+          キャンセル
+        </button>
       </form>
     </section>
 
@@ -114,11 +144,13 @@
       @cancel="cancelReservation"
     />
 
-    <section>
+    <section class="ui-panel operator-portal__section">
       <h2>マイページ</h2>
       <p v-if="!token">マイページはログイン中ユーザーのみ表示できます。</p>
       <template v-else>
-        <button type="button" @click="loadMyPage">マイページを更新</button>
+        <button class="ui-button ui-button--secondary" type="button" @click="loadMyPage">
+          マイページを更新
+        </button>
         <p v-if="myPageLoaded && myPageReservations.length === 0">予約はありません。</p>
         <ul v-else>
           <li v-for="reservation in myPageReservations" :key="`mypage-${reservation}`">
@@ -263,3 +295,23 @@ onMounted(() => {
   void loadOperatorBootstrap();
 });
 </script>
+
+<style scoped>
+.operator-portal {
+  gap: var(--space-4);
+}
+
+.operator-portal__section {
+  align-content: start;
+}
+
+form {
+  display: grid;
+  gap: var(--space-2);
+}
+
+label {
+  display: grid;
+  gap: var(--space-1);
+}
+</style>

--- a/frontend/src/views/ParticipantView.vue
+++ b/frontend/src/views/ParticipantView.vue
@@ -1,5 +1,5 @@
 <template>
-  <main class="participant-portal" :class="`participant-portal--${participantMode}`">
+  <main class="participant-portal ui-shell" :class="participantShellClass">
     <ParticipantTopBar
       event-name="Tokyo Product Summit 2026"
       :date-label="participantDateLabel"
@@ -8,18 +8,19 @@
       @login="runParticipantAction(loginAsGuest)"
     />
 
-    <p v-if="errorMessage" class="participant-feedback participant-feedback--error">
+    <p v-if="errorMessage" class="participant-feedback ui-status ui-status--error">
       {{ errorMessage }}
     </p>
-    <p v-if="infoMessage" class="participant-feedback participant-feedback--success">
+    <p v-if="infoMessage" class="participant-feedback ui-status ui-status--success">
       {{ infoMessage }}
     </p>
 
-    <section class="participant-portal__body">
+    <section class="participant-portal__body ui-layout-split">
       <section class="participant-sessions" aria-label="session list">
         <header class="participant-sessions__header">
           <h2>セッション一覧</h2>
           <button
+            class="ui-button ui-button--secondary"
             type="button"
             :disabled="!hasToken || participantBusy"
             @click="runParticipantAction(loadSessions)"
@@ -74,7 +75,7 @@
 
     <p
       v-if="participantMode === 'loading'"
-      class="participant-feedback participant-feedback--loading"
+      class="participant-feedback ui-status ui-status--loading"
     >
       予約情報を更新中です...
     </p>
@@ -167,6 +168,13 @@ const participantMode = computed<'default' | 'loading' | 'success' | 'error'>(()
   return 'default';
 });
 
+const participantShellClass = computed<Record<string, boolean>>(() => ({
+  'ui-shell--participant': true,
+  'ui-shell--participant-loading': participantMode.value === 'loading',
+  'ui-shell--participant-success': participantMode.value === 'success',
+  'ui-shell--participant-error': participantMode.value === 'error',
+}));
+
 const availabilitySeatTone = (status: SessionAvailabilityStatus): 'open' | 'few' | 'full' => {
   if (status === 'OPEN') {
     return 'open';
@@ -193,26 +201,13 @@ onMounted(() => {
 
 <style scoped>
 .participant-portal {
-  display: grid;
   gap: var(--semantic-component-participant-portal-gap);
-  width: min(980px, 100%);
-  margin: 0 auto;
   padding: var(--semantic-component-participant-portal-padding);
-  border-radius: var(--semantic-component-participant-portal-radius);
-  border: 1px solid var(--semantic-color-participant-portal-border);
-  background: linear-gradient(
-    160deg,
-    var(--semantic-color-participant-portal-bg-start),
-    var(--semantic-color-participant-portal-bg-mid) 48%,
-    var(--semantic-color-participant-portal-bg-end)
-  );
   font-family: 'IBM Plex Sans JP', 'Noto Sans JP', sans-serif;
 }
 
 .participant-portal__body {
-  display: grid;
   gap: 12px;
-  grid-template-columns: 1.35fr 1fr;
 }
 
 .participant-sessions {
@@ -231,22 +226,6 @@ onMounted(() => {
   font-size: 14px;
 }
 
-.participant-sessions__header button {
-  height: var(--semantic-component-participant-button-secondary-height);
-  padding: 0 var(--semantic-component-participant-button-padding-x);
-  border: none;
-  border-radius: var(--semantic-component-participant-button-secondary-radius);
-  background: var(--semantic-color-participant-action-secondary-bg);
-  color: var(--semantic-color-participant-action-secondary-text);
-  font-size: var(--semantic-component-participant-button-text-size);
-  font-weight: var(--semantic-component-participant-button-text-weight);
-}
-
-.participant-sessions__header button:disabled {
-  opacity: 0.6;
-  cursor: not-allowed;
-}
-
 .participant-side {
   display: grid;
   gap: 10px;
@@ -254,49 +233,18 @@ onMounted(() => {
 }
 
 .participant-feedback {
-  margin: 0;
   padding: var(--semantic-component-participant-feedback-padding-y)
     var(--semantic-component-participant-feedback-padding-x);
   border-radius: var(--semantic-component-participant-feedback-radius);
-  font-size: 13px;
-  font-weight: 700;
-}
-
-.participant-feedback--loading {
-  background: var(--semantic-color-participant-feedback-loading-bg);
-  color: var(--semantic-color-participant-feedback-loading-text);
-}
-
-.participant-feedback--success {
-  background: var(--semantic-color-participant-feedback-success-bg);
-  color: var(--semantic-color-participant-feedback-success-text);
-}
-
-.participant-feedback--error {
-  background: var(--semantic-color-participant-feedback-error-bg);
-  color: var(--semantic-color-participant-feedback-error-text);
-}
-
-.participant-portal--loading {
-  border-color: var(--semantic-color-participant-portal-border-loading);
-}
-
-.participant-portal--success {
-  border-color: var(--semantic-color-participant-portal-border-success);
-}
-
-.participant-portal--error {
-  border-color: var(--semantic-color-participant-portal-border-error);
 }
 
 @media (max-width: 900px) {
   .participant-portal {
-    width: min(390px, 100%);
     padding: 12px;
   }
 
   .participant-portal__body {
-    grid-template-columns: 1fr;
+    gap: 10px;
   }
 }
 </style>


### PR DESCRIPTION
## 概要
- Issue #31 の受け入れ条件に対応するため、共通CSS基盤（base/layout/components/state）を導入し、participant/admin/operator の3導線へ適用しました。

## 変更内容
- `frontend/src/styles/base.css` `layout.css` `components.css` `state.css` を追加し、`frontend/src/main.ts` から読み込み。
- `/participant` `/admin` `/operator` の View と主要コンポーネントへ `ui-shell / ui-button / ui-field / ui-table / ui-status` を適用。
- loading / success / error / disabled の状態表現を共通クラスで統一し、モバイル時のレイアウト崩れを防ぐレスポンシブルールを追加。

## 確認手順
1. `cd frontend && pnpm install`
2. `cd frontend && pnpm dev` を起動し、`/participant` `/admin` `/operator` の各画面で共通スタイルが適用されていることを確認する。
3. 各導線で `loading / success / error / disabled` の状態表示と、モバイル幅（390px）でのレイアウト崩れがないことを確認する。

## テスト
- [x] `frontend` のテストを実行した
- [ ] `backend` のテストを実行した（本PRはFrontend変更のみ）
- [ ] ローカルで起動確認した

実行コマンド（必要に応じて）:
```bash
cd frontend && pnpm lint
cd frontend && pnpm typecheck
cd frontend && pnpm test
```

## 影響範囲
- [x] Frontend
- [ ] Backend
- [ ] Database（Migrationあり）
- [ ] CI/CD
- [ ] ドキュメント

## 破壊的変更
- [x] なし
- [ ] あり（内容を記載）

## 関連Issue
- Closes #31
- Related #なし

## レビューポイント
- `ui-shell / ui-button / ui-field / ui-table / ui-status` の適用方針が3導線で一貫しているか。
- 既存機能（予約・管理・チェックイン）を維持したまま状態表示とレスポンシブ改善ができているか。
- `frontend/src/styles/*.css` の責務分割（base/layout/components/state）が妥当か。

## 補足
- `pnpm lint` は既存ファイル（E2E/Storybook）由来の warning が残っていますが、エラーはありません。
