### PR TITLE
[Post-MVP][US-16] クライアントでの機密トークン永続保存を廃止する

### DIFF
--- a/frontend/src/App.test.ts
+++ b/frontend/src/App.test.ts
@@ -1,5 +1,5 @@
 import { mount } from '@vue/test-utils';
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { createMemoryHistory, createRouter } from 'vue-router';
 import App from './App.vue';
 import { routes } from './router/routes';
@@ -23,10 +23,14 @@ const mountAt = async (path: string) => {
 describe('App routing', () => {
   beforeEach(() => {
     window.localStorage.clear();
+    window.sessionStorage.clear();
+    vi.unstubAllGlobals();
   });
 
   afterEach(() => {
     window.localStorage.clear();
+    window.sessionStorage.clear();
+    vi.unstubAllGlobals();
   });
 
   it('redirects root route to participant flow', async () => {
@@ -58,6 +62,26 @@ describe('App routing', () => {
     expect(wrapper.text()).toContain('管理権限がないため /admin の管理画面を表示できません。');
     expect(wrapper.text()).toContain('参加者画面へ戻る');
     expect(wrapper.text()).not.toContain('セッション管理（運営）');
+  });
+
+  it('does not restore admin access from localStorage on /admin route', async () => {
+    window.localStorage.setItem('adminAccessToken', 'legacy-persisted-token');
+    const wrapper = await mountAt('/admin');
+
+    expect(wrapper.text()).toContain('管理権限がないため /admin の管理画面を表示できません。');
+    expect(wrapper.text()).not.toContain('セッション管理（運営）');
+  });
+
+  it('restores admin access from sessionStorage on /admin route', async () => {
+    window.sessionStorage.setItem('adminAccessToken', 'session-token');
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => new Response(JSON.stringify({ sessions: [] }), { status: 200 })),
+    );
+    const wrapper = await mountAt('/admin');
+
+    expect(wrapper.text()).toContain('セッション管理（運営）');
+    expect(wrapper.text()).not.toContain('管理権限がないため /admin の管理画面を表示できません。');
   });
 
   it('keeps operator check-in flow reachable on /operator route', async () => {

--- a/frontend/src/composables/useReservationApp.ts
+++ b/frontend/src/composables/useReservationApp.ts
@@ -120,9 +120,9 @@ const readErrorMessage = async (response: globalThis.Response): Promise<string |
 };
 
 export const useReservationApp = () => {
-  const token = ref<string | null>(globalThis.localStorage.getItem('guestAccessToken'));
-  const adminToken = ref<string>(globalThis.localStorage.getItem('adminAccessToken') ?? '');
-  const guestId = ref<string>(globalThis.localStorage.getItem('guestId') ?? '');
+  const token = ref<string | null>(globalThis.sessionStorage.getItem('guestAccessToken'));
+  const adminToken = ref<string>(globalThis.sessionStorage.getItem('adminAccessToken') ?? '');
+  const guestId = ref<string>(globalThis.sessionStorage.getItem('guestId') ?? '');
 
   const sessions = ref<SessionSummary[]>([]);
   const adminSessions = ref<AdminSession[]>([]);
@@ -645,8 +645,8 @@ export const useReservationApp = () => {
     checkInResultMessage.value = '';
     checkInResultTone.value = '';
 
-    globalThis.localStorage.setItem('guestAccessToken', data.accessToken);
-    globalThis.localStorage.setItem('guestId', data.guestId);
+    globalThis.sessionStorage.setItem('guestAccessToken', data.accessToken);
+    globalThis.sessionStorage.setItem('guestId', data.guestId);
 
     await Promise.all([loadSessions(), loadReservations(), loadMyPage(), loadCheckInHistory()]);
   };
@@ -667,8 +667,19 @@ export const useReservationApp = () => {
     }
   };
 
+  const endAdminSession = (): void => {
+    adminToken.value = '';
+    adminSessions.value = [];
+    clearEditForm();
+    infoMessage.value = '管理者セッションを終了しました。';
+  };
+
   watch(adminToken, (newValue) => {
-    globalThis.localStorage.setItem('adminAccessToken', newValue);
+    if (newValue.trim().length === 0) {
+      globalThis.sessionStorage.removeItem('adminAccessToken');
+      return;
+    }
+    globalThis.sessionStorage.setItem('adminAccessToken', newValue);
   });
 
   watch(
@@ -754,6 +765,7 @@ export const useReservationApp = () => {
     createAdminSession,
     startEditSession,
     updateAdminSession,
+    endAdminSession,
     checkInEvent,
     checkInSession,
     loadCheckInHistory,

--- a/frontend/src/views/AdminView.vue
+++ b/frontend/src/views/AdminView.vue
@@ -9,6 +9,14 @@
     />
 
     <AdminAccessGate v-model="adminToken" />
+    <button
+      v-if="hasAdminAccess"
+      class="ui-button ui-button--secondary"
+      type="button"
+      @click="endAdminSession"
+    >
+      管理者セッションを終了
+    </button>
     <AdminAccessDeniedPanel
       v-if="!hasAdminAccess"
       :message="'管理権限がないため /admin の管理画面を表示できません。管理者トークンを設定するか、参加者画面へ戻ってください。'"
@@ -80,6 +88,7 @@ const {
   editForm,
   clearEditForm,
   loadAdminSessions,
+  endAdminSession,
   downloadReservationCsv,
   downloadSessionCheckInCsv,
   createAdminSession,

--- a/frontend/src/views/OperatorView.vue
+++ b/frontend/src/views/OperatorView.vue
@@ -40,6 +40,14 @@
       >
         チェックインCSVを出力
       </button>
+      <button
+        class="ui-button ui-button--secondary"
+        type="button"
+        :disabled="!adminToken"
+        @click="endAdminSession"
+      >
+        管理者セッションを終了
+      </button>
 
       <form @submit.prevent="createAdminSession">
         <h3>新規作成</h3>
@@ -237,6 +245,7 @@ const {
   loadReservations,
   loadMyPage,
   loadAdminSessions,
+  endAdminSession,
   reserveKeynote,
   reserveSession,
   cancelReservation,


### PR DESCRIPTION
## 概要
- Issue #34 の対応として、クライアントでの管理者トークン永続保存を廃止し、セッション終了時に破棄できるようにしました。

## 変更内容
- `useReservationApp` のトークン保存先を `localStorage` から `sessionStorage` へ変更（admin/guest）
- 管理者トークン破棄処理 `endAdminSession` を追加し、`/admin` と `/operator` から実行可能に変更
- ルーティングテストを更新し、`localStorage` では管理画面復元されないこと・`sessionStorage` のみで復元されることを追加検証

## 確認手順
1. `cd frontend && pnpm dev` で起動し `/admin` へアクセス
2. 管理者トークン入力後に「管理者セッションを終了」を押し、管理画面が非表示に戻ることを確認
3. ブラウザ再起動後に `/admin` を開き、再認証が必要であることを確認

## テスト
- [x] `frontend` のテストを実行した
- [ ] `backend` のテストを実行した（今回変更なしのため未実施）
- [ ] ローカルで起動確認した（未実施）

実行コマンド（必要に応じて）:
```bash
cd frontend && pnpm lint && pnpm typecheck && pnpm test && pnpm build
```

## 影響範囲
- [x] Frontend
- [ ] Backend
- [ ] Database（Migrationあり）
- [ ] CI/CD
- [ ] ドキュメント

## 破壊的変更
- [x] なし
- [ ] あり（内容を記載）

## 関連Issue
- Closes #34
- Related #33

## レビューポイント
- `sessionStorage` への切り替えにより、管理者トークンが永続化されない挙動になっているか
- セッション終了ボタン押下後に保護API操作が実行できないUI/状態になっているか

## 補足
- `frontend lint` は既存の Prettier 警告が9件ありますが、今回差分外のため未対応です。
