### PR TITLE
[Issue #68] セッション一覧APIにdisplayOrderを追加

### DIFF
--- a/backend/src/main/java/com/event/reservation/api/SessionSummaryResponse.java
+++ b/backend/src/main/java/com/event/reservation/api/SessionSummaryResponse.java
@@ -9,6 +9,7 @@ public record SessionSummaryResponse(List<SessionSummary> sessions) {
         String title,
         String startTime,
         String track,
+        Integer displayOrder,
         SessionAvailabilityStatus availabilityStatus
     ) {
     }

--- a/backend/src/test/java/com/event/export/CsvExportServiceTest.java
+++ b/backend/src/test/java/com/event/export/CsvExportServiceTest.java
@@ -94,6 +94,7 @@ class CsvExportServiceTest {
                         "Session 1",
                         "10:30",
                         "Track A",
+                        1,
                         SessionAvailabilityStatus.OPEN
                     )
                 )
@@ -138,6 +139,7 @@ class CsvExportServiceTest {
                         "-Session 1",
                         "@10:30",
                         "Track A",
+                        1,
                         SessionAvailabilityStatus.OPEN
                     )
                 )

--- a/backend/src/test/java/com/event/reservation/ReservationServiceTest.java
+++ b/backend/src/test/java/com/event/reservation/ReservationServiceTest.java
@@ -40,6 +40,18 @@ class ReservationServiceTest {
     }
 
     @Test
+    void listSessionsIncludesDisplayOrderForDefaultTracks() {
+        ReservationService reservationService = new ReservationService(20, 200, EVENT_DATE, fixedClockAt("2026-01-01T08:00:00Z"));
+
+        SessionSummaryResponse response = reservationService.listSessions();
+
+        assertThat(response.sessions().get(0).displayOrder()).isEqualTo(0);
+        assertThat(response.sessions().get(1).displayOrder()).isEqualTo(1);
+        assertThat(response.sessions().get(2).displayOrder()).isEqualTo(2);
+        assertThat(response.sessions().get(3).displayOrder()).isEqualTo(3);
+    }
+
+    @Test
     void reserveSessionReplacesReservationForSameStartTime() {
         ReservationService reservationService = new ReservationService(200, 200, EVENT_DATE, fixedClockAt("2026-01-01T09:00:00Z"));
 
@@ -115,6 +127,19 @@ class ReservationServiceTest {
         assertThat(reservationService.listSessions().sessions())
             .extracting(SessionSummaryResponse.SessionSummary::title)
             .contains("New Session");
+    }
+
+    @Test
+    void createSessionSetsNullDisplayOrderForUnknownTrack() {
+        ReservationService reservationService = new ReservationService(200, 200, EVENT_DATE, fixedClockAt("2026-01-01T08:00:00Z"));
+        reservationService.createSession("New Session", "16:30", "Track D", 30);
+
+        SessionSummaryResponse.SessionSummary createdSession = reservationService.listSessions().sessions().stream()
+            .filter(session -> session.sessionId().equals("session-16"))
+            .findFirst()
+            .orElseThrow();
+
+        assertThat(createdSession.displayOrder()).isNull();
     }
 
     @Test

--- a/backend/src/test/java/com/event/security/GuestAdminFlowTest.java
+++ b/backend/src/test/java/com/event/security/GuestAdminFlowTest.java
@@ -62,7 +62,8 @@ class GuestAdminFlowTest extends GuestFlowIntegrationTestBase {
                 .header(HttpHeaders.AUTHORIZATION, bearer(ADMIN_TOKEN)))
             .andExpect(status().isOk())
             .andExpect(jsonPath("$.sessions[16].sessionId").value("session-16"))
-            .andExpect(jsonPath("$.sessions[16].title").value("Admin Updated Session"));
+            .andExpect(jsonPath("$.sessions[16].title").value("Admin Updated Session"))
+            .andExpect(jsonPath("$.sessions[16].displayOrder").isEmpty());
     }
 
     @Test

--- a/backend/src/test/java/com/event/security/GuestAuthenticationApiFlowTest.java
+++ b/backend/src/test/java/com/event/security/GuestAuthenticationApiFlowTest.java
@@ -65,8 +65,10 @@ class GuestAuthenticationApiFlowTest extends GuestFlowIntegrationTestBase {
             .andExpect(status().isOk())
             .andExpect(jsonPath("$.sessions.length()").value(16))
             .andExpect(jsonPath("$.sessions[0].sessionId").value("keynote"))
+            .andExpect(jsonPath("$.sessions[0].displayOrder").value(0))
             .andExpect(jsonPath("$.sessions[0].availabilityStatus").value("FEW_LEFT"))
             .andExpect(jsonPath("$.sessions[1].startTime").isNotEmpty())
-            .andExpect(jsonPath("$.sessions[1].track").isNotEmpty());
+            .andExpect(jsonPath("$.sessions[1].track").isNotEmpty())
+            .andExpect(jsonPath("$.sessions[1].displayOrder").value(1));
     }
 }


### PR DESCRIPTION
## 概要
- セッション一覧API（`/api/reservations/sessions`）のレスポンスに `displayOrder` を追加し、トラック表示順をAPI側で表現できるようにします。

## 変更内容
- `SessionSummaryResponse.SessionSummary` に `displayOrder`（`Integer`）を追加
- `ReservationService` にトラック別の表示順マッピングを追加し、`displayOrder` をレスポンスへ設定
- 既存テストを更新し、`displayOrder` の返却（既知トラック）と `null`（未知トラック）を検証するテストを追加

## 確認手順
1. `cd backend`
2. `./gradlew test`
3. `GuestAuthenticationApiFlowTest#sessionListApiIsAvailableForGuestLogin` で `displayOrder` が返ることを確認

## テスト
- [ ] `frontend` のテストを実行した
- [x] `backend` のテストを実行した
- [ ] ローカルで起動確認した

実行コマンド（必要に応じて）:
```bash
cd backend && ./gradlew test
```

## 仕様準拠チェック（UI/CSS変更がある場合）
- [ ] 契約クラス（例: `ui-shell` / `ui-button` / `ui-field` / `ui-table` / `ui-status`）を使用している
- [ ] 状態バリエーション（`loading` / `success` / `error` / `disabled`）を要件どおり網羅している
- [ ] 禁止事項（直値カラー、画面ごとの独自disabled表現、エラー表示位置の不統一）に抵触していない

## 影響範囲
- [ ] Frontend
- [x] Backend
- [ ] Database（Migrationあり）
- [ ] CI/CD
- [ ] ドキュメント

## 破壊的変更
- [x] なし
- [ ] あり（内容を記載）

## 関連Issue
- Closes #68
- Related #35

## レビューポイント
- 既知トラック（Keynote/Track A/B/C）への `displayOrder` 付与ルールが妥当か
- 未知トラックを `null` で返す方針が `#35` 側のフォールバック実装と整合するか

## 補足
- 本PRは #68 のスコープに合わせて Backend API と Backend テストのみに限定しています。
